### PR TITLE
소셜 로그인 (카카오) 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # .env.example
 
 JWT_SECRET=your_secret_key
+KAKAO_CLIENT_ID=your_secret_key
+KAKAO_REDIRECT_URI=your_secret_key

--- a/src/main/java/com/ceos/menual/domain/auth/api/KakaoOauthClient.java
+++ b/src/main/java/com/ceos/menual/domain/auth/api/KakaoOauthClient.java
@@ -5,8 +5,11 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 
 import com.ceos.menual.domain.auth.dto.response.KakaoUserResponseDTO;
+import com.ceos.menual.domain.auth.exception.AuthErrorCode;
+import com.ceos.menual.global.exception.GlobalException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,27 +29,47 @@ public class KakaoOauthClient {
 	private final WebClient kakaoApiWebClient;
 
 	public String getAccessToken(String code) {
-		return kakaoAuthWebClient.post()
-			.uri(uriBuilder -> uriBuilder
-				.path("/oauth/token")
-				.queryParam("grant_type", "authorization_code")
-				.queryParam("client_id", clientId)
-				.queryParam("redirect_uri", redirectUri)
-				.queryParam("code", code)
-				.build())
-			.retrieve()
-			.bodyToMono(Map.class)
-			.map(res -> (String)res.get("access_token"))
-			.block();
+		try {
+			return kakaoAuthWebClient.post()
+				.uri(uriBuilder -> uriBuilder
+					.path("/oauth/token")
+					.queryParam("grant_type", "authorization_code")
+					.queryParam("client_id", clientId)
+					.queryParam("redirect_uri", redirectUri)
+					.queryParam("code", code)
+					.build())
+				.retrieve()
+				.bodyToMono(Map.class)
+				.map(res -> {
+					String accessToken = (String) res.get("access_token");
+					if (accessToken == null) {
+						throw new GlobalException(AuthErrorCode.KAKAO_TOKEN_ERROR);
+					}
+					return accessToken;
+				})
+				.block();
+		} catch (WebClientRequestException e){
+			throw new GlobalException(AuthErrorCode.KAKAO_TOKEN_ERROR);
+		}
 	}
 
 	public KakaoUserResponseDTO getUserInfo(String accessToken){
-		return kakaoApiWebClient.get()
-			.uri("/v2/user/me")
-			.headers(headers -> headers.setBearerAuth(accessToken))
-			.retrieve()
-			.bodyToMono(KakaoUserResponseDTO.class)
-			.block();
+		try {
+			KakaoUserResponseDTO userInfo = kakaoApiWebClient.get()
+				.uri("/v2/user/me")
+				.headers(headers -> headers.setBearerAuth(accessToken))
+				.retrieve()
+				.bodyToMono(KakaoUserResponseDTO.class)
+				.block();
+
+			if (userInfo == null){
+				throw new GlobalException(AuthErrorCode.KAKAO_USER_INFO_ERROR);
+			}
+			return userInfo;
+
+		}catch (WebClientRequestException e){
+			throw new GlobalException(AuthErrorCode.KAKAO_USER_INFO_ERROR);
+		}
 	}
 
 }

--- a/src/main/java/com/ceos/menual/domain/auth/api/KakaoOauthClient.java
+++ b/src/main/java/com/ceos/menual/domain/auth/api/KakaoOauthClient.java
@@ -1,0 +1,52 @@
+package com.ceos.menual.domain.auth.api;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.ceos.menual.domain.auth.dto.response.KakaoUserResponseDTO;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoOauthClient {
+
+	@Value("${kakao.client-id}")
+	private String clientId;
+
+	@Value("${kakao.redirect-uri}")
+	private String redirectUri;
+
+	private final WebClient kakaoAuthWebClient;
+	private final WebClient kakaoApiWebClient;
+
+	public String getAccessToken(String code) {
+		return kakaoAuthWebClient.post()
+			.uri(uriBuilder -> uriBuilder
+				.path("/oauth/token")
+				.queryParam("grant_type", "authorization_code")
+				.queryParam("client_id", clientId)
+				.queryParam("redirect_uri", redirectUri)
+				.queryParam("code", code)
+				.build())
+			.retrieve()
+			.bodyToMono(Map.class)
+			.map(res -> (String)res.get("access_token"))
+			.block();
+	}
+
+	public KakaoUserResponseDTO getUserInfo(String accessToken){
+		return kakaoApiWebClient.get()
+			.uri("/v2/user/me")
+			.headers(headers -> headers.setBearerAuth(accessToken))
+			.retrieve()
+			.bodyToMono(KakaoUserResponseDTO.class)
+			.block();
+	}
+
+}

--- a/src/main/java/com/ceos/menual/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ceos/menual/domain/auth/controller/AuthController.java
@@ -1,9 +1,15 @@
 package com.ceos.menual.domain.auth.controller;
 
+import com.ceos.menual.domain.auth.dto.request.KakaoLoginRequestDTO;
+import com.ceos.menual.domain.auth.dto.response.KakaoLoginResponseDTO;
 import com.ceos.menual.domain.auth.dto.request.LoginRequestDTO;
 import com.ceos.menual.domain.auth.dto.response.LoginResponseDTO;
 import com.ceos.menual.domain.auth.service.AuthService;
+import com.ceos.menual.domain.common.dto.response.CommonResponse;
+import com.ceos.menual.entity.User;
 import com.ceos.menual.global.config.jwt.CookieUtil;
+
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -36,4 +42,14 @@ public class AuthController {
 
         return ResponseEntity.ok(loginResponse);
     }
+
+    @PostMapping("/social-login")
+    @Operation(summary = "카카오 로그인", description = "카카오 인가코드를 받아 로그인합니다.")
+    public CommonResponse<KakaoLoginResponseDTO> login(@RequestBody KakaoLoginRequestDTO request, HttpServletResponse response){
+        User user = authService.socialLogin(request.getCode(), request.getProvider(), response);
+        KakaoLoginResponseDTO result = new KakaoLoginResponseDTO(user.getNickname(), user.getUserType().name());
+        return CommonResponse.success(result);
+    }
+
+
 }

--- a/src/main/java/com/ceos/menual/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ceos/menual/domain/auth/controller/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
             description = "사용자 이메일과 비밀번호를 이용해 로그인하고, 발급된 AccessToken과 RefreshToken을 httpOnly 쿠키로 전송한다."
     )
     @PostMapping("/login")
-    public ResponseEntity<CommonResponse<LoginResponseDTO>> login(
+    public ResponseEntity<CommonResponse<LoginResponseDTO>> socialLogin(
             @Valid @RequestBody LoginRequestDTO request,
             HttpServletResponse response
     ) {

--- a/src/main/java/com/ceos/menual/domain/auth/dto/request/KakaoLoginRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/auth/dto/request/KakaoLoginRequestDTO.java
@@ -1,0 +1,16 @@
+package com.ceos.menual.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description="소셜 로그인 요청")
+public class KakaoLoginRequestDTO {
+
+	@Schema(description = "인가 코드", example="abc123xyz")
+	private String code;
+
+	@Schema(description = "소셜 제공자", example="KAKAO")
+	private String provider;
+
+}

--- a/src/main/java/com/ceos/menual/domain/auth/dto/response/KakaoLoginResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/auth/dto/response/KakaoLoginResponseDTO.java
@@ -1,0 +1,18 @@
+package com.ceos.menual.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "카카오 로그인 응답")
+public class KakaoLoginResponseDTO {
+
+	@Schema(description = "사용자 닉네임", example="철수")
+	private String nickname;
+
+	@Schema(description = "사용자 역할", example="TMP_USER")
+	private String role;
+
+}

--- a/src/main/java/com/ceos/menual/domain/auth/dto/response/KakaoUserResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/auth/dto/response/KakaoUserResponseDTO.java
@@ -1,0 +1,20 @@
+package com.ceos.menual.domain.auth.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUserResponseDTO {
+
+	private Long id;
+	private KakaoAccount kakao_account;
+
+	@Getter
+	public static class KakaoAccount {
+		private Profile profile;
+
+		@Getter
+		public static class Profile {
+			private String nickname;
+		}
+	}
+}

--- a/src/main/java/com/ceos/menual/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/auth/exception/AuthErrorCode.java
@@ -16,7 +16,8 @@ public enum AuthErrorCode  implements ResultCode {
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, 1005, "잘못된 JWT 서명입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1006, "Refresh Token을 찾을 수 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 1007, "유효하지 않은 Refresh Token입니다."),
-    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1008, "토큰이 존재하지 않습니다.");
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1008, "토큰이 존재하지 않습니다."),
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, 1009, "지원하지 않는 소셜 제공자입니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/ceos/menual/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/auth/exception/AuthErrorCode.java
@@ -17,7 +17,10 @@ public enum AuthErrorCode  implements ResultCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1006, "Refresh Token을 찾을 수 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 1007, "유효하지 않은 Refresh Token입니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1008, "토큰이 존재하지 않습니다."),
-    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, 1009, "지원하지 않는 소셜 제공자입니다.");
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, 1009, "지원하지 않는 소셜 제공자입니다."),
+    KAKAO_TOKEN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1010, "카카오 토큰 요청에 실패했습니다."),
+    KAKAO_USER_INFO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1011, "카카오 사용자 정보 요청에 실패했습니다.")
+    ;
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/ceos/menual/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ceos/menual/domain/auth/service/AuthService.java
@@ -62,6 +62,7 @@ public class AuthService {
     @Transactional
     public User socialLogin(String code, String provider, HttpServletResponse response) {
 
+        Long providerId;
         String nickname;
         String email;
 
@@ -71,6 +72,7 @@ public class AuthService {
 
             // accessToken으로 사용자 정보 요청
             KakaoUserResponseDTO kakaoUser = kakaoOauthClient.getUserInfo(accessToken);
+            providerId = kakaoUser.getId();
             nickname = kakaoUser.getKakao_account().getProfile().getNickname();
 
             email = "kakao_" + UUID.randomUUID().toString().substring(0, 10) + "@kakao.user";
@@ -83,7 +85,7 @@ public class AuthService {
         }
 
         // DB 저장 또는 조회
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByProviderAndProviderId(AuthProvider.valueOf(provider.toUpperCase()), providerId.toString())
             .orElseGet(() -> userRepository.save(
                 User.builder()
                     .email(email)
@@ -91,6 +93,7 @@ public class AuthService {
                     .password("")
                     .userType(UserType.TMP_USER)
                     .provider(AuthProvider.valueOf(provider.toUpperCase()))
+                    .providerId(providerId.toString())
                     .agreeTerms(false)
                     .agreePrivacy(false)
                     .build()

--- a/src/main/java/com/ceos/menual/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ceos/menual/domain/auth/service/AuthService.java
@@ -1,14 +1,25 @@
 package com.ceos.menual.domain.auth.service;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.ceos.menual.domain.auth.api.KakaoOauthClient;
 import com.ceos.menual.domain.auth.dto.request.LoginRequestDTO;
+import com.ceos.menual.domain.auth.dto.response.KakaoUserResponseDTO;
 import com.ceos.menual.domain.auth.dto.response.LoginResponseDTO;
 import com.ceos.menual.domain.auth.exception.AuthErrorCode;
 import com.ceos.menual.domain.auth.exception.UserErrorCode;
 import com.ceos.menual.domain.user.repository.UserRepository;
 import com.ceos.menual.entity.User;
+import com.ceos.menual.entity.enums.AuthProvider;
+import com.ceos.menual.entity.enums.UserType;
+import com.ceos.menual.global.config.jwt.CookieUtil;
 import com.ceos.menual.global.config.jwt.JwtProvider;
 import com.ceos.menual.global.config.jwt.JwtValidator;
 import com.ceos.menual.global.exception.GlobalException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -23,6 +34,8 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
     private final JwtValidator jwtValidator;
+    private final CookieUtil cookieUtil;
+    private final KakaoOauthClient kakaoOauthClient;
 
     public LoginResponseDTO login(LoginRequestDTO request) {
         // 사용자 조회
@@ -45,6 +58,52 @@ public class AuthService {
                 .refreshToken(refreshToken)
                 .build();
     }
+
+    @Transactional
+    public User socialLogin(String code, String provider, HttpServletResponse response) {
+
+        String nickname;
+        String email;
+
+        if(provider.equalsIgnoreCase("KAKAO")){
+            // 인가코드로 카카오 access token 발급
+            String accessToken = kakaoOauthClient.getAccessToken(code);
+
+            // accessToken으로 사용자 정보 요청
+            KakaoUserResponseDTO kakaoUser = kakaoOauthClient.getUserInfo(accessToken);
+            nickname = kakaoUser.getKakao_account().getProfile().getNickname();
+
+            email = "kakao_" + UUID.randomUUID().toString().substring(0, 10) + "@kakao.user";
+        }
+        //else if(provider.equalsIgnoreCase("GOOGLE")){
+        //
+        // }
+        else{
+            throw new GlobalException(AuthErrorCode.INVALID_PROVIDER);
+        }
+
+        // DB 저장 또는 조회
+        User user = userRepository.findByEmail(email)
+            .orElseGet(() -> userRepository.save(
+                User.builder()
+                    .email(email)
+                    .nickname(nickname)
+                    .password("")
+                    .userType(UserType.TMP_USER)
+                    .provider(AuthProvider.valueOf(provider.toUpperCase()))
+                    .agreeTerms(false)
+                    .agreePrivacy(false)
+                    .build()
+            ));
+
+        String jwtAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtProvider.createRefreshToken(user.getId());
+        cookieUtil.addAccessTokenCookie(response, jwtAccessToken);
+        cookieUtil.addRefreshTokenCookie(response, refreshToken);
+
+        return user;
+    }
+
 
     public String refresh(String refreshToken) {
         // Refresh Token 검증

--- a/src/main/java/com/ceos/menual/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ceos/menual/domain/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.ceos.menual.domain.user.repository;
 
 import com.ceos.menual.entity.User;
+import com.ceos.menual.entity.enums.AuthProvider;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -12,5 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 
 }

--- a/src/main/java/com/ceos/menual/domain/user/service/UserService.java
+++ b/src/main/java/com/ceos/menual/domain/user/service/UserService.java
@@ -4,6 +4,8 @@ import com.ceos.menual.domain.user.dto.request.SignUpRequestDTO;
 import com.ceos.menual.domain.user.dto.response.SignUpResponseDTO;
 import com.ceos.menual.domain.user.repository.UserRepository;
 import com.ceos.menual.entity.User;
+import com.ceos.menual.entity.enums.AuthProvider;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -41,6 +43,7 @@ public class UserService {
                 .password(passwordEncoder.encode(request.getPassword()))
                 .birth(parseBirthDate(request.getBirth()))
                 .userType(request.getUserType())
+                .provider(AuthProvider.LOCAL)
                 .agreeTerms(request.getAgreeTerms())
                 .agreePrivacy(request.getAgreePrivacy())
                 .build();

--- a/src/main/java/com/ceos/menual/entity/User.java
+++ b/src/main/java/com/ceos/menual/entity/User.java
@@ -37,7 +37,11 @@ public class User extends BaseEntity {
     private UserType userType;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private AuthProvider provider;
+
+    @Column
+    private String providerId;
 
     @Column(nullable = false)
     private Boolean agreeTerms;

--- a/src/main/java/com/ceos/menual/entity/User.java
+++ b/src/main/java/com/ceos/menual/entity/User.java
@@ -1,5 +1,6 @@
 package com.ceos.menual.entity;
 
+import com.ceos.menual.entity.enums.AuthProvider;
 import com.ceos.menual.entity.enums.UserType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -34,6 +35,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserType userType;
+
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
 
     @Column(nullable = false)
     private Boolean agreeTerms;

--- a/src/main/java/com/ceos/menual/entity/enums/AuthProvider.java
+++ b/src/main/java/com/ceos/menual/entity/enums/AuthProvider.java
@@ -1,0 +1,5 @@
+package com.ceos.menual.entity.enums;
+
+public enum AuthProvider {
+	LOCAL, KAKAO, GOOGLE
+}

--- a/src/main/java/com/ceos/menual/entity/enums/UserType.java
+++ b/src/main/java/com/ceos/menual/entity/enums/UserType.java
@@ -1,6 +1,7 @@
 package com.ceos.menual.entity.enums;
 
 public enum UserType {
+    TMP_USER,
     GROOMER,
     EXPERT
 }

--- a/src/main/java/com/ceos/menual/global/config/SecurityConfig.java
+++ b/src/main/java/com/ceos/menual/global/config/SecurityConfig.java
@@ -40,7 +40,11 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable());
+
 
 
         return http.build();

--- a/src/main/java/com/ceos/menual/global/config/WebClientConfig.java
+++ b/src/main/java/com/ceos/menual/global/config/WebClientConfig.java
@@ -7,7 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
-@RequiredArgsConstructor
 public class WebClientConfig {
 
 	@Bean

--- a/src/main/java/com/ceos/menual/global/config/WebClientConfig.java
+++ b/src/main/java/com/ceos/menual/global/config/WebClientConfig.java
@@ -1,0 +1,28 @@
+package com.ceos.menual.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+
+	@Bean
+	public WebClient kakaoAuthWebClient(){
+		return WebClient.builder()
+			.baseUrl("https://kauth.kakao.com")
+			.defaultHeader("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+			.build();
+	}
+
+	@Bean
+	public WebClient kakaoApiWebClient(){
+		return WebClient.builder()
+			.baseUrl("https://kapi.kakao.com")
+			.defaultHeader("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+			.build();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,7 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 86400000 # 1일
   refresh-token-validity: 604800000 # 7일
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #8 

## 📝작업 내용

> 소셜 로그인 (카카오) 구현했습니다. 

## 📷스크린샷 (선택)
<img width="1605" height="679" alt="KakaoTalk_Photo_2025-11-10-오후 3-11-00" src="https://github.com/user-attachments/assets/fc8d462d-a2a0-4722-84fc-3700a1649880" />


## 💬리뷰 요구사항(선택)

> 바뀐 .env 파일 노션에 업로드 하였습니다. 
user entity에 provider가 추가되서 기본 회원가입 시 provider 값이 LOCAL로 저장되도록 하였습니다. 
UserType의 TMP_USER는 최초 소셜 로그인 시 부여되는 타입입니다. 이후 추가정보를 입력하면 사용자가 선택한 타입으로 변경되도록 할 예정입니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카카오 소셜 로그인 API 추가 — 카카오 인증으로 로그인/회원 생성, 닉네임·역할 응답 제공
  * 임시 사용자(TMP_USER) 발급 및 인증 토큰(액세스/리프레시) 쿠키 발행
  * 인증 제공자(AuthProvider) 및 providerId 저장·제공자 기준 조회 지원

* **Chores**
  * 보안·CORS 설정 조정 및 카카오 연동 설정(환경변수 KAKAO_CLIENT_ID/KAKAO_REDIRECT_URI) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->