### PR TITLE
usertype 제거 및 소셜 로그인 사용자 회원가입 추가

### DIFF
--- a/src/main/java/com/ceos/menual/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ceos/menual/domain/auth/service/AuthService.java
@@ -73,7 +73,7 @@ public class AuthService {
             // accessToken으로 사용자 정보 요청
             KakaoUserResponseDTO kakaoUser = kakaoOauthClient.getUserInfo(accessToken);
             providerId = kakaoUser.getId();
-            nickname = kakaoUser.getKakao_account().getProfile().getNickname();
+            nickname = "kakao_" + UUID.randomUUID().toString().substring(0, 10);
 
             email = "kakao_" + UUID.randomUUID().toString().substring(0, 10) + "@kakao.user";
         }

--- a/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
+++ b/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
@@ -2,13 +2,17 @@ package com.ceos.menual.domain.user.controller;
 
 import com.ceos.menual.domain.common.dto.response.CommonResponse;
 import com.ceos.menual.domain.user.dto.request.SignUpRequestDTO;
+import com.ceos.menual.domain.user.dto.request.SocialSignUpRequestDTO;
 import com.ceos.menual.domain.user.dto.response.SignUpResponseDTO;
+import com.ceos.menual.domain.user.dto.response.SocialSignUpResponseDTO;
 import com.ceos.menual.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +26,7 @@ public class UserController {
     private final UserService userService;
 
     /*
-    회원가입 API 엔드포인트
+    회원가입(기본 로그인 회원) API 엔드포인트
      */
     @Operation(
             summary = "회원가입",
@@ -31,6 +35,24 @@ public class UserController {
     @PostMapping("/signup")
     public ResponseEntity<CommonResponse<SignUpResponseDTO>> signUp(@Valid @RequestBody SignUpRequestDTO request) {
         SignUpResponseDTO response = userService.signUp(request);
+
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+    /*
+    회원가입(소셜 로그인 회원) API 엔드포인트
+     */
+    @Operation(
+        summary = "소셜 로그인 회원가입 (추가 정보 입력)",
+        description = "사용자의 정보를 입력받아 검증한 후 DB에 저장한다."
+    )
+    @PostMapping("/social-signup")
+    public ResponseEntity<CommonResponse<SocialSignUpResponseDTO>> socialSignUp(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal Long userId,
+        @Valid @RequestBody SocialSignUpRequestDTO request
+    ) {
+        SocialSignUpResponseDTO response = userService.socialSignUp(userId, request);
 
         return ResponseEntity.ok(CommonResponse.success(response));
     }

--- a/src/main/java/com/ceos/menual/domain/user/dto/request/SignUpRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/user/dto/request/SignUpRequestDTO.java
@@ -26,8 +26,6 @@ public class SignUpRequestDTO {
     @NotBlank(message = "비밀번호 확인을 입력해주세요.")
     private String passwordConfirm;
 
-    private UserType userType;
-
     @NotNull(message = "이용약관 동의는 필수입니다.")
     @AssertTrue(message = "이용약관에 동의해야 합니다.")
     private Boolean agreeTerms;

--- a/src/main/java/com/ceos/menual/domain/user/dto/request/SocialSignUpRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/user/dto/request/SocialSignUpRequestDTO.java
@@ -1,0 +1,38 @@
+package com.ceos.menual.domain.user.dto.request;
+
+import com.ceos.menual.entity.enums.UserType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "소셜 사용자 회원가입 요청 DTO")
+public class SocialSignUpRequestDTO {
+
+	@Schema(description = "닉네임", example = "철수")
+	@NotBlank(message = "닉네임을 입력해주세요.")
+	private String nickname;
+
+	@Schema(description = "생년월일", example = "20000101")
+	@NotBlank(message = "생년월일을 입력해주세요.")
+	private String birth;
+
+	@Schema(description = "이메일", example = "menual@gmail.com")
+	@NotBlank(message = "이메일을 입력해주세요.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	private String email;
+
+	@Schema(description = "이용약관 동의", example = "true")
+	@NotNull(message = "이용약관 동의는 필수입니다.")
+	@AssertTrue(message = "이용약관에 동의해야 합니다.")
+	private Boolean agreeTerms;
+
+	@Schema(description = "개인정보 처리방침 동의", example = "true")
+	@NotNull(message = "개인정보 처리방침 동의는 필수입니다.")
+	@AssertTrue(message = "개인정보 처리방침에 동의해야 합니다.")
+	private Boolean agreePrivacy;
+}

--- a/src/main/java/com/ceos/menual/domain/user/dto/response/SocialSignUpResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/user/dto/response/SocialSignUpResponseDTO.java
@@ -1,0 +1,21 @@
+package com.ceos.menual.domain.user.dto.response;
+
+import com.ceos.menual.entity.User;
+import com.ceos.menual.entity.enums.UserType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "소셜 사용자 회원가입 응답 DTO")
+public class SocialSignUpResponseDTO {
+
+	@Schema(description = "닉네임", example = "철수")
+	private String nickname;
+
+	@Schema(description = "회원 타입", example = "EXPERT")
+	private UserType userType;
+
+}

--- a/src/main/java/com/ceos/menual/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/user/exception/UserErrorCode.java
@@ -13,7 +13,8 @@ public enum UserErrorCode implements ResultCode {
     INVALID_EMAIL(HttpStatus.NOT_FOUND, 1101, "이메일이 일치하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.CONFLICT, 1102, "비밀번호가 일치하지 않습니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, 1103, "이미 사용 중인 아이디입니다."),
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 1104, "이미 사용 중인 이메일입니다.");
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 1104, "이미 사용 중인 이메일입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 1105, "존재하지 않는 사용자입니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/ceos/menual/domain/user/service/UserService.java
+++ b/src/main/java/com/ceos/menual/domain/user/service/UserService.java
@@ -1,12 +1,15 @@
 package com.ceos.menual.domain.user.service;
 
 import com.ceos.menual.domain.user.dto.request.SignUpRequestDTO;
+import com.ceos.menual.domain.user.dto.request.SocialSignUpRequestDTO;
 import com.ceos.menual.domain.user.dto.response.SignUpResponseDTO;
+import com.ceos.menual.domain.user.dto.response.SocialSignUpResponseDTO;
 import com.ceos.menual.domain.user.exception.UserErrorCode;
 import com.ceos.menual.domain.user.repository.UserRepository;
 import com.ceos.menual.entity.User;
 import com.ceos.menual.entity.enums.AuthProvider;
 
+import com.ceos.menual.entity.enums.UserType;
 import com.ceos.menual.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -42,7 +45,7 @@ public class UserService {
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .birth(parseBirthDate(request.getBirth()))
-                .userType(request.getUserType())
+                .userType(UserType.MENUAL)
                 .provider(AuthProvider.LOCAL)
                 .agreeTerms(request.getAgreeTerms())
                 .agreePrivacy(request.getAgreePrivacy())
@@ -59,6 +62,34 @@ public class UserService {
                 .userType(savedUser.getUserType())
                 .createdAt(savedUser.getCreatedAt())
                 .build();
+    }
+
+    @Transactional
+    public SocialSignUpResponseDTO socialSignUp(Long userId, SocialSignUpRequestDTO request) {
+        // 소셜 로그인 시 생성된 유저인지 검증
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        // 이메일 중복 검사
+        validateDuplicateEmail(request.getEmail());
+
+        // 닉네임 중복 검사
+        validateDuplicateNickname(request.getNickname());
+
+        // 사용자 정보 업데이트
+        user.updateSocialExtraInfo(
+            request.getNickname(),
+            parseBirthDate(request.getBirth()),
+            request.getEmail(),
+            request.getAgreeTerms(),
+            request.getAgreePrivacy()
+        );
+
+        // 저장 후 응답 반환
+        return SocialSignUpResponseDTO.builder()
+            .nickname(user.getNickname())
+            .userType(user.getUserType())
+            .build();
     }
 
     // 관련 메서드

--- a/src/main/java/com/ceos/menual/entity/User.java
+++ b/src/main/java/com/ceos/menual/entity/User.java
@@ -48,4 +48,17 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean agreePrivacy;
+
+    public void updateSocialExtraInfo(String nickname, LocalDate birth, String email, Boolean agreeTerms, Boolean agreePrivacy) {
+        this.nickname = nickname;
+        this.birth = birth;
+        this.email = email;
+        this.agreeTerms = agreeTerms;
+        this.agreePrivacy = agreePrivacy;
+
+        if(this.userType == UserType.TMP_USER){
+            this.userType = UserType.MENUAL;
+        }
+    }
 }
+

--- a/src/main/java/com/ceos/menual/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ceos/menual/global/config/jwt/JwtAuthenticationFilter.java
@@ -33,6 +33,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 클라이언트에서 accessToken 쿠키 추출
         String accessToken = getTokenFromCookie(request, "accessToken");
 
+        // Swagger 테스트용 Bearer Token 지원
+        if (accessToken == null) {
+            String header = request.getHeader("Authorization");
+            if (header != null && header.startsWith("Bearer ")) {
+                accessToken = header.substring(7);
+            }
+        }
 
         if (accessToken != null) {
             try {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

> 기본 회원가입에서 usertype 제거, 소셜 로그인 사용자 회원가입 추가

## 📷스크린샷 (선택)

<img width="1170" height="270" alt="image" src="https://github.com/user-attachments/assets/57238012-98a1-4673-b95a-c5a273c40617" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 소셜 회원가입 기능 추가: 기존 사용자가 추가 정보(닉네임, 생년월일, 이메일 등)를 입력하여 계정을 완성할 수 있습니다.
  * Authorization 헤더의 Bearer 토큰 지원: 쿠키를 통한 인증이 불가능한 경우 Authorization 헤더의 Bearer 토큰으로 인증이 가능해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->