### PR TITLE
TOP3 전문가 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ repositories {
 }
 
 dependencies {
-    //web
+    // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
-    //DB
+    // DB
     runtimeOnly 'org.postgresql:postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
@@ -43,22 +43,28 @@ dependencies {
     // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    //validation
+    // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
-    //lombok
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    //test
+    // QueryDSL (JPA)
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    //env
+    // env
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     implementation 'com.h2database:h2'

--- a/src/main/java/com/ceos/menual/domain/expert/controller/ExpertController.java
+++ b/src/main/java/com/ceos/menual/domain/expert/controller/ExpertController.java
@@ -1,0 +1,53 @@
+package com.ceos.menual.domain.expert.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ceos.menual.domain.common.dto.response.CommonResponse;
+import com.ceos.menual.domain.expert.dto.response.PopularExpertsResponseDTO;
+import com.ceos.menual.domain.expert.service.ExpertService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/expert")
+@RequiredArgsConstructor
+public class ExpertController {
+
+	private final ExpertService expertService;
+
+	/*
+	* 전체 카테고리의 인기 전문가 TOP3 조회 API
+	*/
+	@Operation(
+		summary = "전체 인기 전문가 TOP3 조회",
+		description = "전체 카테고리에서 상담 완료 수 기준 TOP3 전문가를 조회합니다."
+	)
+	@GetMapping("/popular")
+	public ResponseEntity<CommonResponse<PopularExpertsResponseDTO>> getTop3Overall(){
+		PopularExpertsResponseDTO response = expertService.getTop3Overall();
+		return ResponseEntity.ok(CommonResponse.success(response));
+	}
+
+	/*
+	 * 카테고리별 인기 전문가 TOP3 조회 API
+	 */
+	@Operation(
+		summary = "카테고리별 인기 전문가 TOP3 조회",
+		description = "카테고리별로 상담 완료 수 기준 TOP3 전문가를 조회합니다."
+	)
+	@GetMapping("/popular/{categoryId}")
+	public ResponseEntity<CommonResponse<PopularExpertsResponseDTO>> getTop3ByCategory(
+		@Parameter(description = "카테고리 ID", required = true)
+		@PathVariable Long categoryId
+	){
+		PopularExpertsResponseDTO response = expertService.getTop3ByCategory(categoryId);
+		return ResponseEntity.ok(CommonResponse.success(response));
+	}
+
+}

--- a/src/main/java/com/ceos/menual/domain/expert/dto/response/ExpertRankingResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/expert/dto/response/ExpertRankingResponseDTO.java
@@ -1,0 +1,25 @@
+package com.ceos.menual.domain.expert.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "전문가 TOP3")
+public class ExpertRankingResponseDTO {
+
+	@Schema(description = "전문가 이름", example = "김철수")
+	private String name;
+
+	@Schema(description = "전문가 카테고리명", example = "헤어")
+	private String category;
+
+	@Schema(description = "프로필 이미지", example = "http://image.png")
+	private String profileImage;
+
+	@Schema(description = "한 줄 소개", example = "안녕하세요! 헤어 전문가 김철수입니다.")
+	private String introduction;
+}

--- a/src/main/java/com/ceos/menual/domain/expert/dto/response/PopularExpertsResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/expert/dto/response/PopularExpertsResponseDTO.java
@@ -1,0 +1,18 @@
+package com.ceos.menual.domain.expert.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "인기 전문가 TOP3 응답 DTO")
+public class PopularExpertsResponseDTO {
+
+	@Schema(description = "인기 전문가 TOP3 목록")
+	private List<ExpertRankingResponseDTO> top3;
+}

--- a/src/main/java/com/ceos/menual/domain/expert/exception/ExpertErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/expert/exception/ExpertErrorCode.java
@@ -1,0 +1,4 @@
+package com.ceos.menual.domain.expert.exception;
+
+public enum ExpertErrorCode {
+}

--- a/src/main/java/com/ceos/menual/domain/expert/repository/ExpertRepository.java
+++ b/src/main/java/com/ceos/menual/domain/expert/repository/ExpertRepository.java
@@ -1,0 +1,10 @@
+package com.ceos.menual.domain.expert.repository;
+
+import java.util.List;
+
+import com.ceos.menual.domain.expert.dto.response.ExpertRankingResponseDTO;
+
+public interface ExpertRepository {
+	List<ExpertRankingResponseDTO> findTop3Overall();
+	List<ExpertRankingResponseDTO> findTop3ByCategory(Long categoryId);
+}

--- a/src/main/java/com/ceos/menual/domain/expert/repository/ExpertRepositoryImpl.java
+++ b/src/main/java/com/ceos/menual/domain/expert/repository/ExpertRepositoryImpl.java
@@ -1,0 +1,80 @@
+package com.ceos.menual.domain.expert.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.ceos.menual.domain.expert.dto.response.ExpertRankingResponseDTO;
+import com.ceos.menual.entity.QConsultation;
+import com.ceos.menual.entity.QExpertProfile;
+import com.ceos.menual.entity.enums.ConsultationStatus;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ExpertRepositoryImpl implements ExpertRepository {
+	private final JPAQueryFactory queryFactory;
+
+	QExpertProfile ep = QExpertProfile.expertProfile;
+	QConsultation c = QConsultation.consultation;
+
+	@Override
+	public List<ExpertRankingResponseDTO> findTop3Overall() {
+		return queryFactory
+			.select(Projections.constructor(
+				ExpertRankingResponseDTO.class,
+				ep.user.nickname,
+				ep.category.name,
+				ep.profileImage,
+				ep.introduction
+			))
+			.from(ep)
+			.leftJoin(c)
+				.on(c.expertProfile.id.eq(ep.id)
+					.and(c.status.eq(ConsultationStatus.COMPLETED)))
+			.join(ep.user)
+			.join(ep.category)
+			.groupBy(
+				ep.id,
+				ep.user.nickname,
+				ep.category.name,
+				ep.profileImage,
+				ep.introduction
+			)
+			.orderBy(c.id.count().desc())
+			.limit(3)
+			.fetch();
+	}
+
+	@Override
+	public List<ExpertRankingResponseDTO> findTop3ByCategory(Long categoryId) {
+		return queryFactory
+			.select(Projections.constructor(
+				ExpertRankingResponseDTO.class,
+				ep.user.nickname,
+				ep.category.name,
+				ep.profileImage,
+				ep.introduction
+			))
+			.from(ep)
+			.leftJoin(c)
+				.on(c.expertProfile.id.eq(ep.id)
+					.and(c.status.eq(ConsultationStatus.COMPLETED)))
+			.join(ep.user)
+			.join(ep.category)
+			.where(ep.category.id.eq(categoryId))
+			.groupBy(
+				ep.id,
+				ep.user.nickname,
+				ep.category.name,
+				ep.profileImage,
+				ep.introduction
+			)
+			.orderBy(c.id.count().desc())
+			.limit(3)
+			.fetch();
+	}
+}

--- a/src/main/java/com/ceos/menual/domain/expert/repository/ExpertRepositoryImpl.java
+++ b/src/main/java/com/ceos/menual/domain/expert/repository/ExpertRepositoryImpl.java
@@ -18,8 +18,8 @@ import lombok.RequiredArgsConstructor;
 public class ExpertRepositoryImpl implements ExpertRepository {
 	private final JPAQueryFactory queryFactory;
 
-	QExpertProfile ep = QExpertProfile.expertProfile;
-	QConsultation c = QConsultation.consultation;
+	private static final QExpertProfile ep = QExpertProfile.expertProfile;
+	private static final QConsultation c = QConsultation.consultation;
 
 	@Override
 	public List<ExpertRankingResponseDTO> findTop3Overall() {

--- a/src/main/java/com/ceos/menual/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/ExpertService.java
@@ -1,0 +1,30 @@
+package com.ceos.menual.domain.expert.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ceos.menual.domain.expert.dto.response.ExpertRankingResponseDTO;
+import com.ceos.menual.domain.expert.dto.response.PopularExpertsResponseDTO;
+import com.ceos.menual.domain.expert.repository.ExpertRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExpertService {
+
+	private final ExpertRepository expertRepository;
+
+	public PopularExpertsResponseDTO getTop3Overall() {
+		List<ExpertRankingResponseDTO> top3 = expertRepository.findTop3Overall();
+		return new PopularExpertsResponseDTO(top3);
+	}
+
+	public PopularExpertsResponseDTO getTop3ByCategory(Long categoryId) {
+		List<ExpertRankingResponseDTO> top3 = expertRepository.findTop3ByCategory(categoryId);
+		return new PopularExpertsResponseDTO(top3);
+	}
+}

--- a/src/main/java/com/ceos/menual/entity/Consultation.java
+++ b/src/main/java/com/ceos/menual/entity/Consultation.java
@@ -2,6 +2,7 @@ package com.ceos.menual.entity;
 
 import java.time.LocalDateTime;
 
+import com.ceos.menual.entity.enums.ConsultationStatus;
 import com.ceos.menual.entity.enums.ConsultationType;
 import com.ceos.menual.entity.enums.PaymentStatus;
 
@@ -42,6 +43,9 @@ public class Consultation extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	private ConsultationType type;
+
+	@Enumerated(EnumType.STRING)
+	private ConsultationStatus status;
 
 	private LocalDateTime scheduleTime;
 

--- a/src/main/java/com/ceos/menual/entity/ExpertProfile.java
+++ b/src/main/java/com/ceos/menual/entity/ExpertProfile.java
@@ -39,6 +39,9 @@ public class ExpertProfile extends BaseEntity {
 	@OneToOne(mappedBy = "expertProfile", cascade = CascadeType.ALL, orphanRemoval = true)
 	private ExpertBankAccount expertBankAccount;
 
+	//프로필이미지
+	private String profileImage;
+
 	//전문분야
 	private String speciality;
 

--- a/src/main/java/com/ceos/menual/entity/enums/ConsultationStatus.java
+++ b/src/main/java/com/ceos/menual/entity/enums/ConsultationStatus.java
@@ -1,0 +1,8 @@
+package com.ceos.menual.entity.enums;
+
+public enum ConsultationStatus {
+	READY,
+	IN_PROGRESS,
+	COMPLETED,
+	REJECTED
+}

--- a/src/main/java/com/ceos/menual/global/config/QuerydslConfig.java
+++ b/src/main/java/com/ceos/menual/global/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.ceos.menual.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+	private final EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #31 

## 📝작업 내용

> 전체/카테고리별 TOP3 전문가 조회 API 구현하였습니다. 

## 📷스크린샷 (선택)

> 

<img width="2154" height="1510" alt="image" src="https://github.com/user-attachments/assets/6cafdd41-379a-451e-8076-5d6f096960f2" />

<img width="2154" height="1510" alt="image" src="https://github.com/user-attachments/assets/5d685150-b772-4642-a0b7-74968f6d77ca" />


## 💬리뷰 요구사항(선택)

> 추후에 캐시 도입하는 것도 좋을 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인기 전문가 조회 API 추가: 전체 및 카테고리별 상위 3명 조회 엔드포인트 추가
  * 인기 전문가 응답 구조 추가: 상위 3명 목록과 전문가 프로필(이름, 카테고리, 이미지, 한줄소개) 반환

* **데이터 모델 변경**
  * 상담 상태(enum) 추가(READY, IN_PROGRESS, COMPLETED, REJECTED)
  * 전문가 프로필에 프로필 이미지 필드 추가
  * 상담에 상태 필드 추가

* **Chores**
  * QueryDSL 의존성 및 JPAQueryFactory 구성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->