### PR TITLE
실시간/베스트 후기 조회 API 구현

### DIFF
--- a/src/main/java/com/ceos/menual/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/ceos/menual/domain/review/controller/ReviewController.java
@@ -1,0 +1,51 @@
+package com.ceos.menual.domain.review.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ceos.menual.domain.common.dto.response.CommonResponse;
+import com.ceos.menual.domain.review.dto.response.ReviewSummaryResponseDTO;
+import com.ceos.menual.domain.review.service.ReviewService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/review")
+@RequiredArgsConstructor
+public class ReviewController {
+
+	private final ReviewService reviewService;
+
+	/*
+	 * 카테고리별 실시간 후기 조회 API
+	 * (parameter 없으면 전체에서 조회)
+	 */
+	@Operation(summary = "실시간 후기 조회", description = "최신 순으로 후기 목록을 조회합니다.")
+	@GetMapping("/recent")
+	public ResponseEntity<CommonResponse<List<ReviewSummaryResponseDTO>>> getRecentReviews(
+		@RequestParam(required = false) Long categoryId
+	) {
+		List<ReviewSummaryResponseDTO> response = reviewService.getRecentReviews(categoryId);
+		return ResponseEntity.ok(CommonResponse.success(response));
+	}
+
+	/*
+	 * 카테고리별 베스트 후기 조회 API
+	 * (parameter 없으면 전체에서 조회)
+	 */
+	@Operation(summary = "베스트 후기 조회", description = "좋아요 수가 많은 후기 목록을 조회합니다.")
+	@GetMapping("/best")
+	public ResponseEntity<CommonResponse<List<ReviewSummaryResponseDTO>>> getBestReviews(
+		@RequestParam(required = false) Long categoryId
+	){
+		List<ReviewSummaryResponseDTO> response = reviewService.getBestReviews(categoryId);
+		return ResponseEntity.ok(CommonResponse.success(response));
+	}
+
+}

--- a/src/main/java/com/ceos/menual/domain/review/dto/response/ReviewSummaryResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/review/dto/response/ReviewSummaryResponseDTO.java
@@ -1,0 +1,34 @@
+package com.ceos.menual.domain.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "후기 요약 응닫 DTO")
+public class ReviewSummaryResponseDTO {
+
+	@Schema(description = "리뷰 ID")
+	private Long reviewId;
+
+	@Schema(description = "별점")
+	private Integer rating;
+
+	@Schema(description = "내용")
+	private String content;
+
+	@Schema(description = "이미지 URL")
+	private String mediaUrls;
+
+	@Schema(description = "좋아요 수")
+	private Integer likeCount;
+
+	@Schema(description = "카테고리 ID")
+	private Long categoryId;
+
+	@Schema(description = "작성 시간")
+	private String createdAt;
+}

--- a/src/main/java/com/ceos/menual/domain/review/dto/response/ReviewSummaryResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/review/dto/response/ReviewSummaryResponseDTO.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-@Schema(description = "후기 요약 응닫 DTO")
+@Schema(description = "후기 요약 응답 DTO")
 public class ReviewSummaryResponseDTO {
 
 	@Schema(description = "리뷰 ID")

--- a/src/main/java/com/ceos/menual/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ceos/menual/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,11 @@
+package com.ceos.menual.domain.review.repository;
+
+import java.util.List;
+
+import com.ceos.menual.domain.review.dto.response.ReviewSummaryResponseDTO;
+
+public interface ReviewRepository {
+	List<ReviewSummaryResponseDTO> findRecentReviews(Long categoryId);
+
+	List<ReviewSummaryResponseDTO> findBestReviews(Long categoryId);
+}

--- a/src/main/java/com/ceos/menual/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/ceos/menual/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.ceos.menual.domain.review.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.ceos.menual.domain.review.dto.response.ReviewSummaryResponseDTO;
+import com.ceos.menual.entity.QReview;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	private static final QReview r = QReview.review;
+
+	@Override
+	public List<ReviewSummaryResponseDTO> findRecentReviews(Long categoryId) {
+		return queryFactory
+			.select(Projections.constructor(
+				ReviewSummaryResponseDTO.class,
+				r.id,
+				r.rating,
+				r.content,
+				r.mediaUrls,
+				r.likeCount,
+				r.categoryId,
+				r.createdAt.stringValue()
+			))
+			.from(r)
+			.where(categoryId != null ? r.categoryId.eq(categoryId) : null)
+			.orderBy(r.createdAt.desc())
+			.limit(10)
+			.fetch();
+	}
+
+	@Override
+	public List<ReviewSummaryResponseDTO> findBestReviews(Long categoryId) {
+		return queryFactory
+			.select(Projections.constructor(
+				ReviewSummaryResponseDTO.class,
+				r.id,
+				r.rating,
+				r.content,
+				r.mediaUrls,
+				r.likeCount,
+				r.categoryId,
+				r.createdAt.stringValue()
+			))
+			.from(r)
+			.where(categoryId != null ? r.categoryId.eq(categoryId) : null)
+			.orderBy(r.likeCount.desc(), r.createdAt.desc())
+			.limit(10)
+			.fetch();
+	}
+}

--- a/src/main/java/com/ceos/menual/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ceos/menual/domain/review/service/ReviewService.java
@@ -1,0 +1,27 @@
+package com.ceos.menual.domain.review.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ceos.menual.domain.review.dto.response.ReviewSummaryResponseDTO;
+import com.ceos.menual.domain.review.repository.ReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+	private final ReviewRepository reviewRepository;
+
+	public List<ReviewSummaryResponseDTO> getRecentReviews(Long categoryId) {
+		return reviewRepository.findRecentReviews(categoryId);
+	}
+
+	public List<ReviewSummaryResponseDTO> getBestReviews(Long categoryId) {
+		return reviewRepository.findBestReviews(categoryId);
+	}
+}

--- a/src/main/java/com/ceos/menual/entity/Review.java
+++ b/src/main/java/com/ceos/menual/entity/Review.java
@@ -1,5 +1,6 @@
 package com.ceos.menual.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -34,5 +35,21 @@ public class Review extends BaseEntity {
 	private String content;
 
 	private String mediaUrls;
+
+	// 카테고리 ID 캐싱
+	private Long categoryId;
+
+	@Builder.Default
+	private Integer likeCount = 0;
+
+	public void incrementLikeCount() {
+		this.likeCount++;
+	}
+
+	public void decrementLikeCount() {
+		if(this.likeCount > 0){
+			this.likeCount--;
+		}
+	}
 
 }

--- a/src/main/java/com/ceos/menual/entity/Review.java
+++ b/src/main/java/com/ceos/menual/entity/Review.java
@@ -43,13 +43,17 @@ public class Review extends BaseEntity {
 	private Integer likeCount = 0;
 
 	public void incrementLikeCount() {
+		if(this.likeCount == null){
+			this.likeCount = 0;
+		}
 		this.likeCount++;
 	}
 
 	public void decrementLikeCount() {
-		if(this.likeCount > 0){
-			this.likeCount--;
+		if(this.likeCount == null || this.likeCount == 0){
+			return;
 		}
+		this.likeCount--;
 	}
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #40 

## 📝작업 내용

> 실시간/베스트 후기 조회 API를 구현했습니다. 

## 📷스크린샷 (선택)

<img width="1768" height="1542" alt="image" src="https://github.com/user-attachments/assets/1a34c6cd-29b8-4154-8eaa-121105c7a2c5" />
<img width="1768" height="1722" alt="image" src="https://github.com/user-attachments/assets/6bfb4caa-969c-4ef3-bc79-6c5de465db84" />


## 💬리뷰 요구사항(선택)

> 카드가 몇 개 보여지는지 정해지지 않아 일단 10개로 설정해놓았습니다.
또, 추후에 캐싱을 고려하면 좋을 것 같습니다.
Review entity에 categoryID를 캐싱해두는 방법을 사용하려고 하는데 괜찮을까요?
그렇지 않으면 review -> consultation -> expertProfile -> category로 너무 많은 조인이 일어날 것 같아서요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 최근 리뷰 및 인기 리뷰 조회 API 추가(카테고리별 필터링 지원)
  * 리뷰 요약 응답 형식 추가(리뷰 ID, 평점, 내용, 미디어 URL, 좋아요 수, 카테고리, 생성일)
  * 리뷰 좋아요 수 관리 기능 추가(증감 메서드 포함)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->