### PR TITLE
채팅 메세지 목록 조회 API 구현

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -24,7 +24,7 @@ jobs:
           ref: develop
 
       - name: Issue Parser
-        uses: stefanbuck/github-issue-praser@v3
+        uses: stefanbuck/github-issue-parser@v3
         id: issue-parser
         with:
           template-path: .github/ISSUE_TEMPLATE/issue-form.yml

--- a/src/main/java/com/ceos/menual/domain/chat/controller/ChatroomController.java
+++ b/src/main/java/com/ceos/menual/domain/chat/controller/ChatroomController.java
@@ -1,8 +1,10 @@
 package com.ceos.menual.domain.chat.controller;
 
 import com.ceos.menual.domain.chat.dto.request.ChatroomCreateRequestDTO;
+import com.ceos.menual.domain.chat.dto.response.ChatMessageResponseDTO;
 import com.ceos.menual.domain.chat.dto.response.ChatroomListResponseDTO;
 import com.ceos.menual.domain.chat.dto.response.ChatroomResponseDTO;
+import com.ceos.menual.domain.chat.dto.response.MessageReadResponseDTO;
 import com.ceos.menual.domain.chat.service.ChatroomService;
 import com.ceos.menual.domain.common.dto.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,6 +40,26 @@ public class ChatroomController {
             @AuthenticationPrincipal Long memberId
     ) {
         List<ChatroomListResponseDTO> response = chatroomService.getChatroomList(memberId);
+        return CommonResponse.success(response);
+    }
+
+    @Operation(summary = "채팅방 메시지 조회", description = "특정 채팅방의 모든 메시지를 시간순으로 조회합니다.")
+    @GetMapping("/{chatroomId}/messages")
+    public CommonResponse<List<ChatMessageResponseDTO>> getChatroomMessages(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long chatroomId
+    ) {
+        List<ChatMessageResponseDTO> response = chatroomService.getChatroomMessages(memberId, chatroomId);
+        return CommonResponse.success(response);
+    }
+
+    @Operation(summary = "채팅방 메시지 읽음 처리", description = "채팅방의 읽지 않은 모든 메시지를 읽음 상태로 변경합니다.")
+    @PatchMapping("/{chatroomId}/messages/read")
+    public CommonResponse<MessageReadResponseDTO> markMessagesAsRead(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long chatroomId
+    ) {
+        MessageReadResponseDTO response = chatroomService.markAllMessagesAsRead(memberId, chatroomId);
         return CommonResponse.success(response);
     }
 }

--- a/src/main/java/com/ceos/menual/domain/chat/dto/request/ChatMessageDTO.java
+++ b/src/main/java/com/ceos/menual/domain/chat/dto/request/ChatMessageDTO.java
@@ -14,5 +14,6 @@ public class ChatMessageDTO {
     private Long senderId;
     private MessageType messageType;
     private String content;
+    private String imageUrl;
     private Long relatedId; // 연관 리소스, 일반 텍스트면 null
 }

--- a/src/main/java/com/ceos/menual/domain/chat/dto/request/MessageReadRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/chat/dto/request/MessageReadRequestDTO.java
@@ -1,0 +1,12 @@
+package com.ceos.menual.domain.chat.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class MessageReadRequestDTO {
+    private List<Long> messageIds;  // 읽음 처리할 메시지 ID 목록
+}

--- a/src/main/java/com/ceos/menual/domain/chat/dto/response/ChatMessageResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/chat/dto/response/ChatMessageResponseDTO.java
@@ -1,0 +1,39 @@
+package com.ceos.menual.domain.chat.dto.response;
+
+import com.ceos.menual.entity.Message;
+import com.ceos.menual.entity.enums.MessageType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatMessageResponseDTO {
+    private Long messageId;
+    private Long senderId;
+    private String senderRole;  // EXPERT 또는 MEMBER
+    private String senderNickname;
+    private MessageType messageType;
+    private String content;
+    private String imageUrl;
+    private Long relatedId;
+    private LocalDateTime createdAt;
+
+    public static ChatMessageResponseDTO from(
+            Message message,
+            String senderNickname,
+            String senderRole) {
+        return ChatMessageResponseDTO.builder()
+                .messageId(message.getId())
+                .senderId(message.getSenderId())
+                .senderRole(senderRole)
+                .senderNickname(senderNickname)
+                .messageType(message.getMessageType())
+                .content(message.getContent())
+                .imageUrl(message.getImageUrl())
+                .relatedId(message.getRelatedId())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ceos/menual/domain/chat/dto/response/ChatroomListResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/chat/dto/response/ChatroomListResponseDTO.java
@@ -2,6 +2,7 @@ package com.ceos.menual.domain.chat.dto.response;
 
 import com.ceos.menual.entity.enums.ChatroomType;
 import com.ceos.menual.entity.enums.Category;
+import com.ceos.menual.entity.enums.MessageType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -44,6 +45,10 @@ public class ChatroomListResponseDTO {
 
     @Schema(description = "마지막 메시지 전송 시간", example = "2025-12-25T15:30:00")
     private LocalDateTime lastMessageAt;
+
+    // 메시지 타입
+    @Schema(description = "메시지 타입", example = "MESSAGE")
+    private MessageType lastMessageType;
 
     @Schema(description = "안 읽은 메시지 개수", example = "3")
     private Long unreadCount;

--- a/src/main/java/com/ceos/menual/domain/chat/dto/response/MessageReadResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/chat/dto/response/MessageReadResponseDTO.java
@@ -1,0 +1,16 @@
+package com.ceos.menual.domain.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MessageReadResponseDTO {
+    private Integer readCount;  // 읽음 처리된 메시지 개수
+
+    public static MessageReadResponseDTO of(int count) {
+        return MessageReadResponseDTO.builder()
+                .readCount(count)
+                .build();
+    }
+}

--- a/src/main/java/com/ceos/menual/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/chat/exception/ChatErrorCode.java
@@ -9,7 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ChatErrorCode  implements ResultCode {
 
-    ERROR_SAVING_MESSAGE(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "메시지 저장 중 오류가 발생했습니다.");
+    ERROR_SAVING_MESSAGE(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "메시지 저장 중 오류가 발생했습니다."),
+    CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, 5002, "채팅방을 찾을 수 없습니다."),
+    CHATROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, 5003, "채팅방에 접근 권한이 없습니다."),
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, 5004, "메시지를 찾을 수 없습니다.");
+
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/ceos/menual/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ceos/menual/domain/chat/repository/ChatMessageRepository.java
@@ -2,6 +2,7 @@ package com.ceos.menual.domain.chat.repository;
 
 import com.ceos.menual.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -14,9 +15,10 @@ import java.util.stream.Collectors;
 @Repository
 public interface ChatMessageRepository extends JpaRepository<Message, Long> {
 
+    List<Message> findByChatroomIdOrderByCreatedAtAsc(Long chatroomId);
+
     /**
      * 특정 채팅방의 마지막 메시지 조회
-     * (Message 엔티티에 chatroomId 필드가 있다고 가정)
      */
     Optional<Message> findFirstByChatroomIdOrderByCreatedAtDesc(Long chatroomId);
 
@@ -77,4 +79,14 @@ public interface ChatMessageRepository extends JpaRepository<Message, Long> {
                         arr -> (Long) arr[1]   // count
                 ));
     }
+
+    /**
+     * 특정 채팅방의 모든 읽지 않은 메시지를 읽음 처리
+     */
+    @Modifying
+    @Query("UPDATE Message m SET m.isRead = true " +
+            "WHERE m.chatroomId = :chatroomId " +
+            "AND m.senderId != :memberId " +
+            "AND m.isRead = false")
+    int markAllMessagesAsReadInChatroom(@Param("chatroomId") Long chatroomId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/ceos/menual/domain/chat/service/ChatService.java
+++ b/src/main/java/com/ceos/menual/domain/chat/service/ChatService.java
@@ -1,7 +1,7 @@
 package com.ceos.menual.domain.chat.service;
 
 import com.ceos.menual.domain.chat.dto.request.ChatMessageDTO;
-import com.ceos.menual.domain.chat.repository.MessageRepository;
+import com.ceos.menual.domain.chat.repository.ChatMessageRepository;
 import com.ceos.menual.entity.Message;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatService {
 
-    private final MessageRepository messageRepository;
+    private final ChatMessageRepository messageRepository;
 
     @Transactional
     public void saveMessage(ChatMessageDTO messageDto) {

--- a/src/main/java/com/ceos/menual/domain/chat/service/ChatService.java
+++ b/src/main/java/com/ceos/menual/domain/chat/service/ChatService.java
@@ -18,6 +18,9 @@ public class ChatService {
         // DTO -> Entity 변환
         Message message = Message.create(messageDto);
 
+
+        //TODO: Redis 도입 후 스케줄러로 DB에 주기적 저장
+
         // DB 저장
         messageRepository.save(message);
     }

--- a/src/main/java/com/ceos/menual/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ceos/menual/domain/chat/service/ChatroomService.java
@@ -192,7 +192,6 @@ public class ChatroomService {
                 .expertCategory(expertCategoryName)
                 // 메시지 정보
                 .lastMessage(lastMessageText)
-                .lastMessage(lastMessage != null ? lastMessage.getContent() : null)
                 .lastMessageAt(lastMessage != null ? lastMessage.getCreatedAt() : null)
                 .lastMessageType(lastMessageType)
                 .unreadCount(unreadCount)
@@ -203,6 +202,7 @@ public class ChatroomService {
     /**
      * 특정 채팅방의 메시지 목록 조회
      */
+    @Transactional
     public List<ChatMessageResponseDTO> getChatroomMessages(Long memberId, Long chatroomId) {
         // 채팅방 존재 여부 및 권한 확인
         Chatroom chatroom = chatroomRepository.findById(chatroomId)

--- a/src/main/java/com/ceos/menual/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ceos/menual/domain/chat/service/ChatroomService.java
@@ -1,13 +1,18 @@
 package com.ceos.menual.domain.chat.service;
 
 import com.ceos.menual.domain.chat.dto.request.ChatroomCreateRequestDTO;
+import com.ceos.menual.domain.chat.dto.response.ChatMessageResponseDTO;
 import com.ceos.menual.domain.chat.dto.response.ChatroomListResponseDTO;
 import com.ceos.menual.domain.chat.dto.response.ChatroomResponseDTO;
+import com.ceos.menual.domain.chat.dto.response.MessageReadResponseDTO;
+import com.ceos.menual.domain.chat.exception.ChatErrorCode;
 import com.ceos.menual.domain.chat.repository.ChatMessageRepository;
 import com.ceos.menual.domain.chat.repository.ChatroomRepository;
 import com.ceos.menual.domain.consultation.exception.ConsultationErrorCode;
 import com.ceos.menual.domain.consultation.repository.ConsultationRepository;
+import com.ceos.menual.domain.user.repository.UserRepository;
 import com.ceos.menual.entity.*;
+import com.ceos.menual.entity.enums.MessageType;
 import com.ceos.menual.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -28,6 +34,7 @@ public class ChatroomService {
     private final ChatroomRepository chatroomRepository;
     private final ConsultationRepository consultationRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
 
 
     /*
@@ -142,6 +149,37 @@ public class ChatroomService {
             expertCategoryName = chatroom.getExpert().getExpertProfile().getCategory().getDescription();
         }
 
+        // 마지막 메시지 표시 텍스트
+        String lastMessageText = null;
+        MessageType lastMessageType = null;
+
+        String memberNickname = chatroom.getMember().getNickname();
+
+        if (lastMessage != null) {
+            lastMessageType = lastMessage.getMessageType();
+
+            switch (lastMessage.getMessageType()) {
+                case TEXT:
+                    lastMessageText = lastMessage.getContent();
+                    break;
+                case IMAGE:
+                    lastMessageText = "사진을 보냈습니다";
+                    break;
+                case MIXED:
+                    lastMessageText = lastMessage.getContent();  // 텍스트만 표시
+                    break;
+                case QUESTION:
+                    lastMessageText = memberNickname + "님을 위한 고민지가 도착했어요.";
+                    break;
+                case SOLUTION:
+                    lastMessageText = memberNickname + "님을 위한 솔루션지가 도착했어요.";
+                    break;
+                case SYSTEM:
+                    lastMessageText = lastMessage.getContent();
+                    break;
+            }
+        }
+
         // DTO 빌드
         return ChatroomListResponseDTO.builder()
                 .chatroomId(chatroom.getId())
@@ -152,12 +190,105 @@ public class ChatroomService {
                 .opponentNickname(opponent.getNickname())
                 .opponentProfileImage(opponent.getProfileImage())
                 .expertCategory(expertCategoryName)
-                // 메시지 정보 (파라미터로 받은 값 사용)
+                // 메시지 정보
+                .lastMessage(lastMessageText)
                 .lastMessage(lastMessage != null ? lastMessage.getContent() : null)
                 .lastMessageAt(lastMessage != null ? lastMessage.getCreatedAt() : null)
+                .lastMessageType(lastMessageType)
                 .unreadCount(unreadCount)
                 .createdAt(chatroom.getCreatedAt())
                 .build();
+    }
+
+    /**
+     * 특정 채팅방의 메시지 목록 조회
+     */
+    public List<ChatMessageResponseDTO> getChatroomMessages(Long memberId, Long chatroomId) {
+        // 채팅방 존재 여부 및 권한 확인
+        Chatroom chatroom = chatroomRepository.findById(chatroomId)
+                .orElseThrow(() -> new GlobalException(ChatErrorCode.CHATROOM_NOT_FOUND));
+
+        // 채팅방 참여자인지 확인
+        if (!chatroom.getMember().getId().equals(memberId) &&
+                !chatroom.getExpert().getId().equals(memberId)) {
+            throw new GlobalException(ChatErrorCode.CHATROOM_ACCESS_DENIED);
+        }
+
+        // 메시지 목록 조회 (오래된 순)
+        List<Message> messages = chatMessageRepository.findByChatroomIdOrderByCreatedAtAsc(chatroomId);
+
+        if (messages.isEmpty()) {
+            return List.of();
+        }
+
+        // 발신자 정보를 한 번에 조회 (N+1 문제 방지)
+        Set<Long> senderIds = messages.stream()
+                .map(Message::getSenderId)
+                .collect(Collectors.toSet());
+
+        Map<Long, User> userMap = userRepository.findAllById(senderIds).stream()
+                .collect(Collectors.toMap(User::getId, user -> user));
+
+        // DTO 변환
+        List<ChatMessageResponseDTO> responseDTOs = messages.stream()
+                .map(message -> {
+                    User sender = userMap.get(message.getSenderId());
+                    String senderNickname = sender != null ? sender.getNickname() : "알 수 없음";
+
+                    // senderRole 결정: EXPERT 또는 MEMBER
+                    String senderRole = determineSenderRole(chatroom, message.getSenderId());
+
+                    return ChatMessageResponseDTO.from(message, senderNickname, senderRole);
+                })
+                .collect(Collectors.toList());
+
+        // 읽지 않은 메시지 읽음 처리 (현재 사용자가 받은 메시지만)
+        markMessagesAsRead(messages, memberId);
+
+        return responseDTOs;
+    }
+
+    /**
+     * 채팅방의 모든 메시지를 읽음 처리
+     */
+    @Transactional
+    public MessageReadResponseDTO markAllMessagesAsRead(Long memberId, Long chatroomId) {
+        // 채팅방 존재 여부 및 권한 확인
+        Chatroom chatroom = chatroomRepository.findById(chatroomId)
+                .orElseThrow(() -> new GlobalException(ChatErrorCode.CHATROOM_NOT_FOUND));
+
+        if (!chatroom.getMember().getId().equals(memberId) &&
+                !chatroom.getExpert().getId().equals(memberId)) {
+            throw new GlobalException(ChatErrorCode.CHATROOM_ACCESS_DENIED);
+        }
+
+        // 채팅방의 모든 읽지 않은 메시지 읽음 처리 (내가 보낸 메시지 제외)
+        int readCount = chatMessageRepository.markAllMessagesAsReadInChatroom(chatroomId, memberId);
+
+        return MessageReadResponseDTO.of(readCount);
+    }
+
+    /**
+     * 발신자의 역할 결정 (EXPERT or MEMBER)
+     */
+    private String determineSenderRole(Chatroom chatroom, Long senderId) {
+        if (chatroom.getExpert().getId().equals(senderId)) {
+            return "EXPERT";
+        } else if (chatroom.getMember().getId().equals(senderId)) {
+            return "MEMBER";
+        }
+        return "UNKNOWN";
+    }
+
+    /**
+     * 메시지 읽음 처리
+     */
+    @Transactional
+    public void markMessagesAsRead(List<Message> messages, Long memberId) {
+        messages.stream()
+                .filter(message -> !message.getSenderId().equals(memberId))
+                .filter(message -> !message.isRead())
+                .forEach(Message::markAsRead);
     }
 
     /**

--- a/src/main/java/com/ceos/menual/entity/Message.java
+++ b/src/main/java/com/ceos/menual/entity/Message.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "Messages")
-public class Message {
+public class Message extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,8 +28,13 @@ public class Message {
     @Column(name = "user_id")
     private Long senderId;
 
+    // 텍스트 내용
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    // 이미지 url
+    @Column(name = "image_url", columnDefinition = "TEXT")
+    private String imageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "message_type")
@@ -41,15 +46,13 @@ public class Message {
     @Column(name = "related_id")
     private Long relatedId; // 고민지/솔루션지 ID 등
 
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
 
     @Builder
-    public Message(Long chatroomId, Long senderId, String content, MessageType messageType, Long relatedId) {
+    public Message(Long chatroomId, Long senderId, String content, String imageUrl, MessageType messageType, Long relatedId) {
         this.chatroomId = chatroomId;
         this.senderId = senderId;
         this.content = content;
+        this.imageUrl = imageUrl;
         this.messageType = messageType;
         this.relatedId = relatedId;
         this.isRead = false; // 기본값 false
@@ -61,6 +64,7 @@ public class Message {
                 .chatroomId(dto.getChatroomId())
                 .senderId(dto.getSenderId())
                 .content(dto.getContent())
+                .imageUrl(dto.getImageUrl())
                 .messageType(dto.getMessageType())
                 .relatedId(dto.getRelatedId())
                 .build();

--- a/src/main/java/com/ceos/menual/entity/enums/MessageType.java
+++ b/src/main/java/com/ceos/menual/entity/enums/MessageType.java
@@ -3,6 +3,7 @@ package com.ceos.menual.entity.enums;
 public enum MessageType {
     TEXT,
     IMAGE,
+    MIXED,  // 사진 + 텍스트
     QUESTION,
     SOLUTION,
     SYSTEM


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #48 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 채팅 메세지 목록 조회 API 구현

## 📷스크린샷 (선택)

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 채팅에 이미지 전송 지원 추가
  * 채팅방의 모든 메시지 일괄 조회 기능 추가(발신자 닉네임·역할 포함)
  * 채팅방 내 메시지 일괄 읽음 처리 및 읽음 수 반환
  * 마지막 메시지 유형(텍스트/이미지/혼합 등) 표시 개선

* **Bug Fixes**
  * GitHub Actions 워크플로우의 오탈자 수정 (Issue Parser 단계)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->