### PR TITLE
내 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
+++ b/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
@@ -64,7 +64,7 @@ public class UserController {
             description = "현재 로그인한 사용자의 정보를 반환합니다."
     )
     @GetMapping("/me")
-    public ResponseEntity<UserInfoResponseDTO> getMyInfo(
+    public ResponseEntity<CommonResponse<UserInfoResponseDTO>> getMyInfo(
             @AuthenticationPrincipal Long userId) {
         UserInfoResponseDTO response = userService.getMyInfo(userId);
         return ResponseEntity.ok(CommonResponse.success(response));

--- a/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
+++ b/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
@@ -59,10 +59,14 @@ public class UserController {
     /**
      * 내 정보 조회
      */
+    @Operation(
+            summary = "내 정보 조회",
+            description = "현재 로그인한 사용자의 정보를 반환합니다."
+    )
     @GetMapping("/me")
     public ResponseEntity<UserInfoResponseDTO> getMyInfo(
             @AuthenticationPrincipal Long userId) {
         UserInfoResponseDTO response = userService.getMyInfo(userId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(CommonResponse.success(response));
     }
 }

--- a/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
+++ b/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
@@ -5,19 +5,16 @@ import com.ceos.menual.domain.user.dto.request.SignUpRequestDTO;
 import com.ceos.menual.domain.user.dto.request.SocialSignUpRequestDTO;
 import com.ceos.menual.domain.user.dto.response.SignUpResponseDTO;
 import com.ceos.menual.domain.user.dto.response.SocialSignUpResponseDTO;
+import com.ceos.menual.domain.user.dto.response.UserInfoResponseDTO;
 import com.ceos.menual.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/user")
@@ -57,5 +54,15 @@ public class UserController {
         SocialSignUpResponseDTO response = userService.socialSignUp(userId, request);
 
         return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+    /**
+     * 내 정보 조회
+     */
+    @GetMapping("/me")
+    public ResponseEntity<UserInfoResponseDTO> getMyInfo(
+            @AuthenticationPrincipal Long userId) {
+        UserInfoResponseDTO response = userService.getMyInfo(userId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ceos/menual/domain/user/dto/response/UserInfoResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/user/dto/response/UserInfoResponseDTO.java
@@ -1,0 +1,24 @@
+package com.ceos.menual.domain.user.dto.response;
+
+import com.ceos.menual.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInfoResponseDTO {
+
+    private Long userId;
+    private String nickname;
+
+    public static UserInfoResponseDTO from(User user) {
+        return UserInfoResponseDTO.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/ceos/menual/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/user/exception/UserErrorCode.java
@@ -16,7 +16,9 @@ public enum UserErrorCode implements ResultCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, 1104, "이미 사용 중인 이메일입니다."),
     INVALID_BIRTH_FORMAT(HttpStatus.BAD_REQUEST, 1105, "올바르지 않은 생년월일 형식입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 1106, "존재하지 않는 사용자입니다."),
-    GENERAL_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, 1107, "일반 회원 프로필이 존재하지 않습니다.");
+    GENERAL_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, 1107, "일반 회원 프로필이 존재하지 않습니다."),
+    NOT_MEMBER(HttpStatus.FORBIDDEN, 1108, "일반 회원이 아닙니다.");
+
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/ceos/menual/domain/user/service/UserService.java
+++ b/src/main/java/com/ceos/menual/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.ceos.menual.domain.user.dto.request.SignUpRequestDTO;
 import com.ceos.menual.domain.user.dto.request.SocialSignUpRequestDTO;
 import com.ceos.menual.domain.user.dto.response.SignUpResponseDTO;
 import com.ceos.menual.domain.user.dto.response.SocialSignUpResponseDTO;
+import com.ceos.menual.domain.user.dto.response.UserInfoResponseDTO;
 import com.ceos.menual.domain.user.exception.UserErrorCode;
 import com.ceos.menual.domain.user.repository.UserRepository;
 import com.ceos.menual.entity.User;
@@ -120,4 +121,13 @@ public class UserService {
         }
     }
 
+    /**
+     * 현재 로그인한 사용자 정보 조회
+     */
+    public UserInfoResponseDTO getMyInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        return UserInfoResponseDTO.from(user);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #70 (깃허브 이슈 번호를 작성해주세요)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 개발용으로 userId와 nickname만 반환하는 API 구현
- 
## 📷스크린샷 (선택)
<img width="563" height="187" alt="image" src="https://github.com/user-attachments/assets/9d0ef42e-49c2-48bf-b9f5-1eeec53e9717" />

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * GET /api/user/me 엔드포인트 추가로 현재 로그인한 사용자의 기본 정보(사용자 ID, 닉네임)를 조회할 수 있습니다.
  * Swagger/OpenAPI 문서화로 해당 엔드포인트가 API 문서에 반영되었습니다.

* **오류 처리 및 검증 강화**
  * 사용자를 찾을 수 없을 때의 처리와 "일반 회원이 아님" 상황에 대한 명확한 오류 응답을 추가해 안정성을 높였습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->