### PR TITLE
고민지 작성 API 및 결제 확인 API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     // AWS S3
-    implementation 'software.amazon.awssdk:s3:2.25.0'
+    implementation 'software.amazon.awssdk:s3:2.20.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ceos/menual/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ceos/menual/domain/auth/service/AuthService.java
@@ -48,7 +48,7 @@ public class AuthService {
         }
 
         // 토큰 생성
-        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getUserType().name());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());
 
         return LoginResponseDTO.builder()
@@ -99,7 +99,7 @@ public class AuthService {
                     .build()
             ));
 
-        String jwtAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+        String jwtAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getUserType().name());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());
         cookieUtil.addAccessTokenCookie(response, jwtAccessToken);
         cookieUtil.addRefreshTokenCookie(response, refreshToken);
@@ -126,6 +126,6 @@ public class AuthService {
                 .orElseThrow(() -> new GlobalException(UserErrorCode.INVALID_EMAIL));
 
         // 새로운 Access Token 생성
-        return jwtProvider.createAccessToken(user.getId(), user.getEmail());
+        return jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getUserType().name());
     }
 }

--- a/src/main/java/com/ceos/menual/domain/common/controller/S3PresignedUrlController.java
+++ b/src/main/java/com/ceos/menual/domain/common/controller/S3PresignedUrlController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ceos.menual.domain.common.dto.request.DownloadPresignedUrlRequestDTO;
+import com.ceos.menual.domain.common.dto.request.UploadPresignedUrlRequestDTO;
 import com.ceos.menual.domain.common.dto.response.PresignedUrlResponseDTO;
 import com.ceos.menual.domain.common.service.S3PresignedUrlService;
 import com.ceos.menual.domain.common.service.S3PresignedUrlService.GeneratePresignedUrlResponse;
@@ -14,7 +16,6 @@ import com.ceos.menual.domain.common.service.S3PresignedUrlService.GeneratePresi
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -50,7 +51,7 @@ public class S3PresignedUrlController {
 					"유효시간은 15분입니다."
 	)
 	public ResponseEntity<PresignedUrlResponseDTO> getUploadPresignedUrl(
-		@Valid @RequestBody UploadPresignedUrlRequest request) {
+		@Valid @RequestBody UploadPresignedUrlRequestDTO request) {
 
 		GeneratePresignedUrlResponse response = s3PresignedUrlService.generateUploadPresignedUrl(
 			request.getResourceType(),
@@ -78,7 +79,7 @@ public class S3PresignedUrlController {
 		description = "S3에서 파일을 다운로드하기 위한 Presigned URL을 발급합니다. 유효시간은 1시간입니다."
 	)
 	public ResponseEntity<PresignedUrlResponseDTO> getDownloadPresignedUrl(
-		@Valid @RequestBody DownloadPresignedUrlRequest request) {
+		@Valid @RequestBody DownloadPresignedUrlRequestDTO request) {
 
 		GeneratePresignedUrlResponse response = s3PresignedUrlService.generateDownloadPresignedUrl(
 			request.getResourceType(),
@@ -93,38 +94,6 @@ public class S3PresignedUrlController {
 			.expiresIn(response.getExpiresIn())
 			.message("다운로드용 URL이 발급되었습니다. 1시간 내에 다운로드해주세요.")
 			.build());
-	}
-
-	// Request DTOs
-	@lombok.Getter
-	@lombok.NoArgsConstructor
-	@lombok.AllArgsConstructor
-	public static class UploadPresignedUrlRequest {
-		@NotBlank(message = "리소스 타입은 필수입니다. (예: consultation, review)")
-		private String resourceType;
-
-		@NotBlank(message = "이미지 타입은 필수입니다. (예: hairstyle, favorite, purpose)")
-		private String imageType;
-
-		@NotBlank(message = "파일명은 필수입니다.")
-		private String fileName;
-	}
-
-	@lombok.Getter
-	@lombok.NoArgsConstructor
-	@lombok.AllArgsConstructor
-	public static class DownloadPresignedUrlRequest {
-		@NotBlank(message = "리소스 타입은 필수입니다.")
-		private String resourceType;
-
-		@NotBlank(message = "이미지 타입은 필수입니다.")
-		private String imageType;
-
-		@lombok.NonNull
-		private Long resourceId;
-
-		@NotBlank(message = "파일명은 필수입니다.")
-		private String fileName;
 	}
 }
 

--- a/src/main/java/com/ceos/menual/domain/common/controller/S3PresignedUrlController.java
+++ b/src/main/java/com/ceos/menual/domain/common/controller/S3PresignedUrlController.java
@@ -7,13 +7,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ceos.menual.domain.common.dto.request.PresignedUrlRequestDTO;
 import com.ceos.menual.domain.common.dto.response.PresignedUrlResponseDTO;
 import com.ceos.menual.domain.common.service.S3PresignedUrlService;
+import com.ceos.menual.domain.common.service.S3PresignedUrlService.GeneratePresignedUrlResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -30,79 +31,100 @@ public class S3PresignedUrlController {
 	private final S3PresignedUrlService s3PresignedUrlService;
 
 	/**
-	 * S3 업로드용 Presigned URL 발급
+	 * S3 업로드용 Presigned URL 발급 (임시 저장)
 	 * 
-	 * @param request 리소스 타입, ID와 파일명을 포함한 요청
-	 * @return 업로드용 Presigned URL
+	 * @param request resourceType, imageType, fileName을 포함한 요청
+	 * @return 업로드용 Presigned URL과 S3 Key
 	 * 
-	 * 예시:
-	 * - resourceType: "consultation", resourceId: 1, fileName: "hairstyle.jpg"
-	 * - resourceType: "review", resourceId: 5, fileName: "1.jpg"
+	 * 저장 경로: tmp/{resourceType}/user-{userId}/{imageType}/{fileName}
+	 * 결제 확인 후: final/{resourceType}/{resourceId}/{imageType}/{fileName}로 이동
+	 * 
+	 * resourceType 예시: consultation, review, portfolio 등
+	 * imageType 예시: hairstyle, front, left-side, right-side, favorite, purpose 등
 	 */
 	@PostMapping("/upload")
 	@Operation(
 		summary = "업로드용 Presigned URL 발급",
-		description = "S3에 파일을 업로드하기 위한 Presigned URL을 발급합니다. 유효시간은 15분입니다."
+		description = "S3에 이미지를 임시로 업로드하기 위한 Presigned URL을 발급합니다. " +
+					"resourceType(consultation, review 등)과 imageType(hairstyle, favorite 등)을 지정합니다. " +
+					"유효시간은 15분입니다."
 	)
 	public ResponseEntity<PresignedUrlResponseDTO> getUploadPresignedUrl(
-		@Valid @RequestBody PresignedUrlRequestDTO request) {
+		@Valid @RequestBody UploadPresignedUrlRequest request) {
 
-		String uploadUrl = s3PresignedUrlService.generateUploadPresignedUrl(
+		GeneratePresignedUrlResponse response = s3PresignedUrlService.generateUploadPresignedUrl(
 			request.getResourceType(),
-			request.getResourceId(),
+			request.getImageType(),
 			request.getFileName()
 		);
 
-		String s3Key = s3PresignedUrlService.buildS3Key(
-			request.getResourceType(),
-			request.getResourceId(),
-			request.getFileName(),
-			true);
-
-		PresignedUrlResponseDTO response = PresignedUrlResponseDTO.builder()
-			.s3Key(s3Key)
-			.uploadUrl(uploadUrl)
-			.expiresIn(900L) // 15분 = 900초
+		return ResponseEntity.ok(PresignedUrlResponseDTO.builder()
+			.s3Key(response.getS3Key())
+			.uploadUrl(response.getUploadUrl())
+			.expiresIn(response.getExpiresIn())
 			.message("업로드용 URL이 발급되었습니다. 15분 내에 업로드해주세요.")
-			.build();
-
-		return ResponseEntity.ok(response);
+			.build());
 	}
 
 	/**
 	 * S3 다운로드용 Presigned URL 발급
 	 * 
-	 * @param request 리소스 타입, ID와 파일명을 포함한 요청
+	 * @param request 리소스 타입, 이미지 타입, ID와 파일명을 포함한 요청
 	 * @return 다운로드용 Presigned URL
 	 */
 	@PostMapping("/download")
 	@Operation(
-		summary = "다운로드용 Presigned URL 발급",
+		summary = "파일 다운로드용 Presigned URL 발급",
 		description = "S3에서 파일을 다운로드하기 위한 Presigned URL을 발급합니다. 유효시간은 1시간입니다."
 	)
 	public ResponseEntity<PresignedUrlResponseDTO> getDownloadPresignedUrl(
-		@Valid @RequestBody PresignedUrlRequestDTO request) {
+		@Valid @RequestBody DownloadPresignedUrlRequest request) {
 
-		String downloadUrl = s3PresignedUrlService.generateDownloadPresignedUrl(
+		GeneratePresignedUrlResponse response = s3PresignedUrlService.generateDownloadPresignedUrl(
 			request.getResourceType(),
+			request.getImageType(),
 			request.getResourceId(),
 			request.getFileName()
 		);
 
-		String s3Key = s3PresignedUrlService.buildS3Key(
-			request.getResourceType(),
-			request.getResourceId(),
-			request.getFileName(),
-			false);
-
-		PresignedUrlResponseDTO response = PresignedUrlResponseDTO.builder()
-			.s3Key(s3Key)
-			.downloadUrl(downloadUrl)
-			.expiresIn(3600L) // 1시간 = 3600초
+		return ResponseEntity.ok(PresignedUrlResponseDTO.builder()
+			.s3Key(response.getS3Key())
+			.downloadUrl(response.getDownloadUrl())
+			.expiresIn(response.getExpiresIn())
 			.message("다운로드용 URL이 발급되었습니다. 1시간 내에 다운로드해주세요.")
-			.build();
+			.build());
+	}
 
-		return ResponseEntity.ok(response);
+	// Request DTOs
+	@lombok.Getter
+	@lombok.NoArgsConstructor
+	@lombok.AllArgsConstructor
+	public static class UploadPresignedUrlRequest {
+		@NotBlank(message = "리소스 타입은 필수입니다. (예: consultation, review)")
+		private String resourceType;
+
+		@NotBlank(message = "이미지 타입은 필수입니다. (예: hairstyle, favorite, purpose)")
+		private String imageType;
+
+		@NotBlank(message = "파일명은 필수입니다.")
+		private String fileName;
+	}
+
+	@lombok.Getter
+	@lombok.NoArgsConstructor
+	@lombok.AllArgsConstructor
+	public static class DownloadPresignedUrlRequest {
+		@NotBlank(message = "리소스 타입은 필수입니다.")
+		private String resourceType;
+
+		@NotBlank(message = "이미지 타입은 필수입니다.")
+		private String imageType;
+
+		@lombok.NonNull
+		private Long resourceId;
+
+		@NotBlank(message = "파일명은 필수입니다.")
+		private String fileName;
 	}
 }
 

--- a/src/main/java/com/ceos/menual/domain/common/dto/request/DownloadPresignedUrlRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/common/dto/request/DownloadPresignedUrlRequestDTO.java
@@ -1,0 +1,32 @@
+package com.ceos.menual.domain.common.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "S3 다운로드용 Presigned URL 발급 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DownloadPresignedUrlRequestDTO {
+
+	@Schema(description = "리소스 타입", example = "consultation")
+	@NotBlank(message = "리소스 타입은 필수입니다.")
+	private String resourceType;
+
+	@Schema(description = "이미지 타입", example = "favorite")
+	@NotBlank(message = "이미지 타입은 필수입니다.")
+	private String imageType;
+
+	@Schema(description = "리소스 ID", example = "123")
+	@NotNull(message = "리소스 ID는 필수입니다.")
+	private Long resourceId;
+
+	@Schema(description = "파일명", example = "2.jpg")
+	@NotBlank(message = "파일명은 필수입니다.")
+	private String fileName;
+}
+

--- a/src/main/java/com/ceos/menual/domain/common/dto/request/UploadPresignedUrlRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/common/dto/request/UploadPresignedUrlRequestDTO.java
@@ -1,0 +1,27 @@
+package com.ceos.menual.domain.common.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "S3 업로드용 Presigned URL 발급 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UploadPresignedUrlRequestDTO {
+
+	@Schema(description = "리소스 타입", example = "consultation")
+	@NotBlank(message = "리소스 타입은 필수입니다. (예: consultation, review)")
+	private String resourceType;
+
+	@Schema(description = "이미지 타입", example = "hairstyle")
+	@NotBlank(message = "이미지 타입은 필수입니다. (예: hairstyle, favorite, purpose)")
+	private String imageType;
+
+	@Schema(description = "파일명", example = "1.jpg")
+	@NotBlank(message = "파일명은 필수입니다.")
+	private String fileName;
+}
+

--- a/src/main/java/com/ceos/menual/domain/common/entity/S3CleanupTask.java
+++ b/src/main/java/com/ceos/menual/domain/common/entity/S3CleanupTask.java
@@ -1,0 +1,154 @@
+package com.ceos.menual.domain.common.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * S3 파일 정리 작업 기록
+ * - 복사 후 삭제 실패 시 이를 기록하고 나중에 처리
+ * - 스케줄러가 주기적으로 미처리 작업을 재시도
+ */
+@Entity
+@Table(name = "s3_cleanup_tasks")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class S3CleanupTask {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	/**
+	 * S3 버킷명
+	 */
+	@Column(nullable = false)
+	private String bucketName;
+
+	/**
+	 * 삭제 대상 S3 키 (임시 파일 경로)
+	 */
+	@Column(nullable = false, length = 500)
+	private String s3Key;
+
+	/**
+	 * 목적지 S3 키 (최종 파일 경로) - 참조용
+	 */
+	@Column(length = 500)
+	private String destinationS3Key;
+
+	/**
+	 * 작업 상태
+	 */
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private CleanupStatus status;
+
+	/**
+	 * 재시도 횟수
+	 */
+	@Column(nullable = false)
+	private Integer retryCount;
+
+	/**
+	 * 최대 재시도 횟수
+	 */
+	@Column(nullable = false)
+	private Integer maxRetries;
+
+	/**
+	 * 작업 생성 시간
+	 */
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	/**
+	 * 마지막 재시도 시간
+	 */
+	@Column
+	private LocalDateTime lastRetryAt;
+
+	/**
+	 * 완료 시간
+	 */
+	@Column
+	private LocalDateTime completedAt;
+
+	/**
+	 * 에러 메시지
+	 */
+	@Column(columnDefinition = "TEXT")
+	private String errorMessage;
+
+	/**
+	 * 상태 설정
+	 */
+	public void setStatus(CleanupStatus status) {
+		this.status = status;
+	}
+
+	/**
+	 * 작업 상태 열거형
+	 */
+	public enum CleanupStatus {
+		PENDING("대기"),
+		IN_PROGRESS("처리중"),
+		COMPLETED("완료"),
+		FAILED("실패");
+
+		private final String description;
+
+		CleanupStatus(String description) {
+			this.description = description;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+	}
+
+	/**
+	 * 재시도 가능 여부 확인
+	 */
+	public boolean isRetryable() {
+		return retryCount < maxRetries && status != CleanupStatus.COMPLETED;
+	}
+
+	/**
+	 * 재시도 횟수 증가
+	 */
+	public void incrementRetryCount() {
+		this.retryCount++;
+		this.lastRetryAt = LocalDateTime.now();
+	}
+
+	/**
+	 * 작업 완료 처리
+	 */
+	public void markAsCompleted() {
+		this.status = CleanupStatus.COMPLETED;
+		this.completedAt = LocalDateTime.now();
+	}
+
+	/**
+	 * 작업 실패 처리
+	 */
+	public void markAsFailed(String errorMessage) {
+		this.status = CleanupStatus.FAILED;
+		this.errorMessage = errorMessage;
+	}
+}
+

--- a/src/main/java/com/ceos/menual/domain/common/repository/S3CleanupTaskRepository.java
+++ b/src/main/java/com/ceos/menual/domain/common/repository/S3CleanupTaskRepository.java
@@ -1,0 +1,44 @@
+package com.ceos.menual.domain.common.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.ceos.menual.domain.common.entity.S3CleanupTask;
+import com.ceos.menual.domain.common.entity.S3CleanupTask.CleanupStatus;
+
+/**
+ * S3 정리 작업 저장소
+ */
+@Repository
+public interface S3CleanupTaskRepository extends JpaRepository<S3CleanupTask, Long> {
+
+	/**
+	 * 재시도 가능한 미처리 작업 조회 (상태: PENDING 또는 IN_PROGRESS)
+	 */
+	@Query("SELECT t FROM S3CleanupTask t WHERE (t.status = 'PENDING' OR t.status = 'IN_PROGRESS') AND t.retryCount < t.maxRetries ORDER BY t.createdAt ASC")
+	List<S3CleanupTask> findRetryableTasks();
+
+	/**
+	 * 지정된 기간 내에 실패한 작업 조회
+	 */
+	@Query("SELECT t FROM S3CleanupTask t WHERE t.status = :status AND t.createdAt >= :startTime ORDER BY t.createdAt DESC")
+	List<S3CleanupTask> findByStatusAndCreatedAtAfter(@Param("status") CleanupStatus status, @Param("startTime") LocalDateTime startTime);
+
+	/**
+	 * S3 키로 미완료 작업 조회
+	 */
+	@Query("SELECT t FROM S3CleanupTask t WHERE t.s3Key = :s3Key AND t.status != com.ceos.menual.domain.common.entity.S3CleanupTask$CleanupStatus.COMPLETED")
+	List<S3CleanupTask> findPendingByS3Key(@Param("s3Key") String s3Key);
+
+	/**
+	 * 오래된 완료된 작업 조회 (7일 이상 전)
+	 */
+	@Query("SELECT t FROM S3CleanupTask t WHERE t.status = com.ceos.menual.domain.common.entity.S3CleanupTask$CleanupStatus.COMPLETED AND t.completedAt <= :olderThanTime ORDER BY t.completedAt ASC")
+	List<S3CleanupTask> findOldCompletedTasks(@Param("olderThanTime") LocalDateTime olderThanTime);
+}
+

--- a/src/main/java/com/ceos/menual/domain/common/service/S3CleanupScheduler.java
+++ b/src/main/java/com/ceos/menual/domain/common/service/S3CleanupScheduler.java
@@ -1,0 +1,171 @@
+package com.ceos.menual.domain.common.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ceos.menual.domain.common.entity.S3CleanupTask;
+import com.ceos.menual.domain.common.entity.S3CleanupTask.CleanupStatus;
+import com.ceos.menual.domain.common.repository.S3CleanupTaskRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+/**
+ * S3 정리 작업 스케줄러
+ * 
+ * 이 스케줄러는 다음을 담당합니다:
+ * 1. 미처리 정리 작업 재시도 (15분마다)
+ * 2. 완료된 작업 정리 (일 1회)
+ * 3. 장시간 PENDING 상태의 작업 모니터링 (1시간마다)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3CleanupScheduler {
+
+	private final S3CleanupTaskRepository s3CleanupTaskRepository;
+	private final S3Client s3Client;
+
+	@Value("${aws.s3.bucket-name}")
+	private String bucketName;
+
+	@Value("${aws.s3.cleanup.retry-interval-ms:1000}")
+	private Long retryIntervalMs;
+
+	/**
+	 * 미처리된 정리 작업 재시도 (15분마다 실행)
+	 */
+	@Scheduled(fixedRateString = "${aws.s3.cleanup.retry-scheduler-interval:900000}", initialDelayString = "${aws.s3.cleanup.initial-delay:60000}")
+	@Transactional
+	public void retryCleanupTasks() {
+		log.info("[S3 정리 스케줄러] 미처리 정리 작업 재시도 시작");
+
+		List<S3CleanupTask> retryableTasks = s3CleanupTaskRepository.findRetryableTasks();
+
+		if (retryableTasks.isEmpty()) {
+			log.info("[S3 정리 스케줄러] 재시도할 작업 없음");
+			return;
+		}
+
+		log.info("[S3 정리 스케줄러] 재시도 대상 작업 수: {}", retryableTasks.size());
+
+		for (S3CleanupTask task : retryableTasks) {
+			processCleanupTask(task);
+		}
+
+		log.info("[S3 정리 스케줄러] 미처리 정리 작업 재시도 완료");
+	}
+
+	/**
+	 * 개별 정리 작업 처리
+	 */
+	private void processCleanupTask(S3CleanupTask task) {
+		try {
+			log.info("[S3 정리 작업] 처리 시작 - id: {}, s3Key: {}, retryCount: {}/{}", 
+				task.getId(), task.getS3Key(), task.getRetryCount(), task.getMaxRetries());
+
+			// 작업 상태를 IN_PROGRESS로 변경
+			task.incrementRetryCount();
+			task.setStatus(CleanupStatus.IN_PROGRESS);
+			s3CleanupTaskRepository.save(task);
+
+			// S3 파일 삭제 시도
+			DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+				.bucket(task.getBucketName())
+				.key(task.getS3Key())
+				.build();
+
+			s3Client.deleteObject(deleteObjectRequest);
+
+			// 성공 시 작업 완료 처리
+			task.markAsCompleted();
+			s3CleanupTaskRepository.save(task);
+
+			log.info("[S3 정리 작업] 완료 - id: {}, s3Key: {}, 재시도 횟수: {}", 
+				task.getId(), task.getS3Key(), task.getRetryCount());
+
+		} catch (Exception e) {
+			log.error("[S3 정리 작업] 실패 - id: {}, s3Key: {}, bucket: {}, error: {}", 
+				task.getId(), task.getS3Key(), task.getBucketName(), e.getMessage(), e);
+
+			// 재시도 가능 여부 확인
+			if (task.isRetryable()) {
+				task.setStatus(CleanupStatus.PENDING);
+				log.warn("[S3 정리 작업] 다음 재시도 예정 - id: {}, 다음 재시도 횟수: {}/{}", 
+					task.getId(), task.getRetryCount() + 1, task.getMaxRetries());
+			} else {
+				task.markAsFailed(e.getMessage());
+				log.error("[S3 정리 작업] 최대 재시도 초과, 실패 처리 - id: {}, s3Key: {}", 
+					task.getId(), task.getS3Key());
+			}
+
+			s3CleanupTaskRepository.save(task);
+		}
+
+		// 재시도 간격 대기
+		try {
+			Thread.sleep(retryIntervalMs);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.warn("[S3 정리 스케줄러] 재시도 대기 중단됨", e);
+		}
+	}
+
+	/**
+	 * 완료된 작업 정리 (7일 이상 전 완료된 작업 삭제)
+	 * 하루에 1회, 새벽 3시에 실행
+	 */
+	@Scheduled(cron = "${aws.s3.cleanup.old-task-cleanup-cron:0 0 3 * * *}")
+	@Transactional
+	public void cleanupOldCompletedTasks() {
+		log.info("[S3 정리 스케줄러] 오래된 완료 작업 정리 시작");
+
+		LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+		List<S3CleanupTask> oldTasks = s3CleanupTaskRepository.findOldCompletedTasks(sevenDaysAgo);
+
+		if (oldTasks.isEmpty()) {
+			log.info("[S3 정리 스케줄러] 삭제할 오래된 작업 없음");
+			return;
+		}
+
+		log.info("[S3 정리 스케줄러] 오래된 완료 작업 삭제 중 - 삭제 대상: {}개", oldTasks.size());
+
+		s3CleanupTaskRepository.deleteAll(oldTasks);
+
+		log.info("[S3 정리 스케줄러] 오래된 완료 작업 정리 완료 - 삭제됨: {}개", oldTasks.size());
+	}
+
+	/**
+	 * 장시간 PENDING 상태의 작업 모니터링 (1시간마다 실행)
+	 * 
+	 * 오래 처리되지 않는 작업이 있으면 알림 로그 기록
+	 */
+	@Scheduled(fixedRateString = "${aws.s3.cleanup.stale-task-check-interval:3600000}", initialDelayString = "${aws.s3.cleanup.initial-delay:60000}")
+	public void monitorStaleTasks() {
+		log.info("[S3 정리 스케줄러] 장시간 미처리 작업 모니터링 시작");
+
+		LocalDateTime oneHourAgo = LocalDateTime.now().minusHours(1);
+		List<S3CleanupTask> staleTasks = s3CleanupTaskRepository.findByStatusAndCreatedAtAfter(
+			CleanupStatus.PENDING, oneHourAgo);
+
+		if (staleTasks.isEmpty()) {
+			log.debug("[S3 정리 스케줄러] 장시간 미처리 작업 없음");
+			return;
+		}
+
+		log.warn("[S3 정리 스케줄러] 1시간 이상 PENDING 상태인 작업 발견 - 작업 수: {}", staleTasks.size());
+
+		for (S3CleanupTask task : staleTasks) {
+			log.warn("[S3 정리 스케줄러] 장시간 미처리 작업 - id: {}, s3Key: {}, createdAt: {}, retryCount: {}/{}", 
+				task.getId(), task.getS3Key(), task.getCreatedAt(), task.getRetryCount(), task.getMaxRetries());
+		}
+	}
+}
+

--- a/src/main/java/com/ceos/menual/domain/common/service/S3PresignedUrlService.java
+++ b/src/main/java/com/ceos/menual/domain/common/service/S3PresignedUrlService.java
@@ -1,12 +1,17 @@
 package com.ceos.menual.domain.common.service;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import com.ceos.menual.domain.common.entity.S3CleanupTask;
+import com.ceos.menual.domain.common.entity.S3CleanupTask.CleanupStatus;
+import com.ceos.menual.domain.common.repository.S3CleanupTaskRepository;
 
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
@@ -32,12 +37,21 @@ public class S3PresignedUrlService {
 	@Value("${aws.s3.bucket-name}")
 	private String bucketName;
 
+	@Value("${aws.s3.cleanup.max-retries:3}")
+	private Integer maxRetries;
+
+	@Value("${aws.s3.cleanup.retry-interval-ms:1000}")
+	private Long retryIntervalMs;
+
 	private final S3Presigner s3Presigner;
 	private final S3Client s3Client;
+	private final S3CleanupTaskRepository s3CleanupTaskRepository;
 
-	public S3PresignedUrlService(S3Presigner s3Presigner, S3Client s3Client) {
+	public S3PresignedUrlService(S3Presigner s3Presigner, S3Client s3Client, 
+			S3CleanupTaskRepository s3CleanupTaskRepository) {
 		this.s3Presigner = s3Presigner;
 		this.s3Client = s3Client;
+		this.s3CleanupTaskRepository = s3CleanupTaskRepository;
 	}
 
 	/**
@@ -137,8 +151,14 @@ public class S3PresignedUrlService {
 	/**
 	 * S3에서 임시 이미지를 최종 위치로 이동
 	 * 
+	 * 프로세스:
+	 * 1. 임시 위치의 파일을 최종 위치로 복사
+	 * 2. 임시 위치의 파일 삭제 (재시도 로직 포함)
+	 * 3. 삭제 실패 시 정리 작업 기록
+	 * 
 	 * @param tempS3Key 임시 저장 경로 (tmp/consultation/user-{userId}/{imageType}/{fileName})
 	 * @param finalS3Key 최종 저장 경로 (final/consultation/{consultationId}/{imageType}/{fileName})
+	 * @throws RuntimeException 복사 실패 또는 삭제 재시도가 완전히 실패한 경우
 	 */
 	public void moveImageFromTempToFinal(String tempS3Key, String finalS3Key) {
 		try {
@@ -146,6 +166,8 @@ public class S3PresignedUrlService {
 			validateResourceType("final");
 
 			// 1. 임시 위치의 파일을 최종 위치로 복사
+			log.info("S3 파일 복사 시작 - bucket: {}, from: {}, to: {}", bucketName, tempS3Key, finalS3Key);
+			
 			CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
 				.copySource(bucketName + "/" + tempS3Key)
 				.destinationBucket(bucketName)
@@ -153,19 +175,108 @@ public class S3PresignedUrlService {
 				.build();
 
 			s3Client.copyObject(copyObjectRequest);
+			log.info("S3 파일 복사 완료 - from: {}, to: {}", tempS3Key, finalS3Key);
 
-			// 2. 임시 위치의 파일 삭제
-			DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
-				.bucket(bucketName)
-				.key(tempS3Key)
-				.build();
-
-			s3Client.deleteObject(deleteObjectRequest);
+			// 2. 임시 위치의 파일 삭제 (재시도 로직 포함)
+			deleteTemporaryFileWithRetry(tempS3Key, finalS3Key);
 
 			log.info("S3 이미지 이동 완료 - from: {}, to: {}", tempS3Key, finalS3Key);
 		} catch (Exception e) {
-			log.error("S3 이미지 이동 실패 - tempS3Key: {}, finalS3Key: {}", tempS3Key, finalS3Key, e);
+			log.error("S3 이미지 이동 실패 - bucket: {}, tempS3Key: {}, finalS3Key: {}", bucketName, tempS3Key, finalS3Key, e);
 			throw new RuntimeException("S3 이미지 이동 중 오류가 발생했습니다", e);
+		}
+	}
+
+	/**
+	 * 임시 파일 삭제 - 재시도 로직 포함
+	 * 
+	 * 삭제 실패 시:
+	 * - 로컬 재시도 (최대 3회)
+	 * - 모두 실패하면 정리 작업을 DB에 기록
+	 * - 스케줄러가 주기적으로 재처리
+	 * 
+	 * @param tempS3Key 삭제 대상 파일 경로
+	 * @param finalS3Key 최종 파일 경로 (참조용)
+	 * @throws RuntimeException 모든 재시도 실패 후
+	 */
+	private void deleteTemporaryFileWithRetry(String tempS3Key, String finalS3Key) {
+		int attempt = 0;
+		Exception lastException = null;
+
+		log.info("임시 파일 삭제 시작 - bucket: {}, key: {}", bucketName, tempS3Key);
+
+		// 로컬 재시도 루프
+		while (attempt < maxRetries) {
+			attempt++;
+			try {
+				DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+					.bucket(bucketName)
+					.key(tempS3Key)
+					.build();
+
+				s3Client.deleteObject(deleteObjectRequest);
+				log.info("임시 파일 삭제 성공 - bucket: {}, key: {}, attempt: {}/{}", 
+					bucketName, tempS3Key, attempt, maxRetries);
+				return; // 성공 시 메서드 종료
+
+			} catch (Exception e) {
+				lastException = e;
+				log.warn("임시 파일 삭제 실패 (재시도 가능) - bucket: {}, key: {}, attempt: {}/{}, error: {}", 
+					bucketName, tempS3Key, attempt, maxRetries, e.getMessage());
+
+				// 마지막 시도가 아니면 대기 후 재시도
+				if (attempt < maxRetries) {
+					try {
+						Thread.sleep(retryIntervalMs);
+					} catch (InterruptedException ie) {
+						Thread.currentThread().interrupt();
+						log.warn("재시도 대기 중단됨", ie);
+					}
+				}
+			}
+		}
+
+		// 모든 로컬 재시도 실패 → 정리 작업 기록
+		log.error("로컬 재시도 모두 실패 - 정리 작업 DB에 기록 - bucket: {}, key: {}", bucketName, tempS3Key);
+		persistCleanupTask(tempS3Key, finalS3Key, lastException);
+
+		// 정리 작업이 기록되었음을 호출자에게 알림
+		throw new RuntimeException(
+			String.format("S3 임시 파일 삭제 재시도 실패 (정리 작업 기록됨) - bucket: %s, key: %s, 최대 재시도: %d",
+				bucketName, tempS3Key, maxRetries),
+			lastException
+		);
+	}
+
+	/**
+	 * 정리 작업을 DB에 기록
+	 * 
+	 * 스케줄러가 주기적으로 이 작업들을 조회하여 재처리
+	 * 
+	 * @param tempS3Key 삭제 대상 파일 경로
+	 * @param finalS3Key 최종 파일 경로 (참조용)
+	 * @param exception 발생한 예외
+	 */
+	private void persistCleanupTask(String tempS3Key, String finalS3Key, Exception exception) {
+		try {
+			S3CleanupTask cleanupTask = S3CleanupTask.builder()
+				.bucketName(bucketName)
+				.s3Key(tempS3Key)
+				.destinationS3Key(finalS3Key)
+				.status(CleanupStatus.PENDING)
+				.retryCount(0)
+				.maxRetries(maxRetries)
+				.createdAt(LocalDateTime.now())
+				.errorMessage(exception != null ? exception.getMessage() : "초기 삭제 실패")
+				.build();
+
+			s3CleanupTaskRepository.save(cleanupTask);
+			log.info("정리 작업 기록됨 - id: {}, bucket: {}, key: {}, destination: {}", 
+				cleanupTask.getId(), bucketName, tempS3Key, finalS3Key);
+
+		} catch (Exception e) {
+			log.error("정리 작업 기록 실패 - bucket: {}, key: {}, error: {}", 
+				bucketName, tempS3Key, e.getMessage(), e);
 		}
 	}
 

--- a/src/main/java/com/ceos/menual/domain/common/service/S3PresignedUrlService.java
+++ b/src/main/java/com/ceos/menual/domain/common/service/S3PresignedUrlService.java
@@ -1,20 +1,31 @@
 package com.ceos.menual.domain.common.service;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * S3 Presigned URL 발급 서비스 (공통)
  * consultation, review 등 여러 도메인에서 사용 가능
+ * 
+ * 임시 파일 저장 경로: tmp/consultation/user-{userId}/{imageType}/{fileName}
+ * 최종 파일 저장 경로: final/consultation/{consultationId}/{imageType}/{fileName}
  */
+@Slf4j
 @Service
 public class S3PresignedUrlService {
 
@@ -22,20 +33,33 @@ public class S3PresignedUrlService {
 	private String bucketName;
 
 	private final S3Presigner s3Presigner;
+	private final S3Client s3Client;
 
-	public S3PresignedUrlService(S3Presigner s3Presigner) {
+	public S3PresignedUrlService(S3Presigner s3Presigner, S3Client s3Client) {
 		this.s3Presigner = s3Presigner;
+		this.s3Client = s3Client;
 	}
 
 	/**
-	 * Presigned URL 발급 (업로드용)
+	 * Presigned URL 발급 (업로드용 - 임시 저장)
+	 * 
+	 * 경로 구조: tmp/consultation/user-{userId}/{imageType}/{fileName}
+	 * 
 	 * @param resourceType 리소스 타입 (consultation, review 등)
-	 * @param resourceId 리소스 ID
-	 * @param fileName 파일명 (예: hairstyle.jpg, front.jpg, favorite/1.jpg)
-	 * @return Presigned URL
+	 * @param imageType 이미지 타입 (hairstyle, front, left-side, right-side, favorite, purpose)
+	 * @param fileName 파일명 (예: image.jpg, 1.jpg)
+	 * @return Presigned URL과 S3 Key
 	 */
-	public String generateUploadPresignedUrl(String resourceType, Long resourceId, String fileName) {
-		String s3Key = buildS3Key(resourceType, resourceId, fileName, true);
+	public GeneratePresignedUrlResponse generateUploadPresignedUrl(String resourceType, String imageType, String fileName) {
+		// 현재 사용자 ID 가져오기
+		Long userId = getCurrentUserId();
+
+		validateResourceType(resourceType);
+		validateImageType(imageType);
+		validateFileName(fileName);
+
+		// S3 Key 생성 - imageType에 따라 경로 구조가 다름
+		String s3Key = buildTemporaryS3Key(userId, resourceType, imageType, fileName);
 
 		PutObjectRequest putObjectRequest = PutObjectRequest.builder()
 			.bucket(bucketName)
@@ -47,18 +71,41 @@ public class S3PresignedUrlService {
 			.putObjectRequest(putObjectRequest)
 			.build();
 
-		return s3Presigner.presignPutObject(presignRequest).url().toString();
+		String uploadUrl = s3Presigner.presignPutObject(presignRequest).url().toString();
+
+		return GeneratePresignedUrlResponse.builder()
+			.s3Key(s3Key)
+			.uploadUrl(uploadUrl)
+			.expiresIn(900L) // 15분 = 900초
+			.build();
+	}
+
+	/**
+	 * 임시 저장 경로 생성
+	 * tmp/consultation/user-{userId}/{imageType}/{fileName}
+	 */
+	private String buildTemporaryS3Key(Long userId, String resourceType, String imageType, String fileName) {
+		return String.format("tmp/%s/user-%d/%s/%s", resourceType, userId, imageType, fileName);
 	}
 
 	/**
 	 * Presigned URL 발급 (다운로드용)
+	 * 
+	 * 경로 구조: final/consultation/{consultationId}/{imageType}/{fileName}
+	 * 
 	 * @param resourceType 리소스 타입 (consultation, review 등)
-	 * @param resourceId 리소스 ID
+	 * @param imageType 이미지 타입
+	 * @param resourceId 리소스 ID (consultation ID, review ID 등)
 	 * @param fileName 파일명
-	 * @return Presigned URL
+	 * @return Presigned URL과 S3 Key
 	 */
-	public String generateDownloadPresignedUrl(String resourceType, Long resourceId, String fileName) {
-		String s3Key = buildS3Key(resourceType, resourceId, fileName, false);
+	public GeneratePresignedUrlResponse generateDownloadPresignedUrl(String resourceType, String imageType, Long resourceId, String fileName) {
+		validateResourceType(resourceType);
+		validateImageType(imageType);
+		validateFileName(fileName);
+
+		// S3 Key 생성 - imageType에 따라 경로 구조가 다름
+		String s3Key = buildFinalS3Key(resourceType, imageType, resourceId, fileName);
 
 		GetObjectRequest getObjectRequest = GetObjectRequest.builder()
 			.bucket(bucketName)
@@ -70,48 +117,119 @@ public class S3PresignedUrlService {
 			.getObjectRequest(getObjectRequest)
 			.build();
 
-		return s3Presigner.presignGetObject(presignRequest).url().toString();
+		String downloadUrl = s3Presigner.presignGetObject(presignRequest).url().toString();
+
+		return GeneratePresignedUrlResponse.builder()
+			.s3Key(s3Key)
+			.downloadUrl(downloadUrl)
+			.expiresIn(3600L) // 1시간 = 3600초
+			.build();
 	}
 
 	/**
-	 * S3 Key 생성
-	 * @param resourceType 리소스 타입 (consultation, review 등)
-	 * @param resourceId 리소스 ID
-	 * @param fileName 파일명
-	 * @param isTemporary 임시 경로 여부 (true: tmp/ 접두사 추가)
-	 * @return S3 Key (예: tmp/consultation/123/hairstyle.jpg)
+	 * 최종 저장 경로 생성
+	 * final/consultation/{consultationId}/{imageType}/{fileName}
 	 */
-	public String buildS3Key(String resourceType, Long resourceId, String fileName, boolean isTemporary) {
-		validateInputs(resourceType, resourceId, fileName);
-		String basePath = isTemporary ? "tmp/" : "";
-		return String.format("%s%s/%d/%s", basePath, resourceType, resourceId, fileName);
+	private String buildFinalS3Key(String resourceType, String imageType, Long resourceId, String fileName) {
+		return String.format("final/%s/%d/%s/%s", resourceType, resourceId, imageType, fileName);
 	}
 
 	/**
-	 * S3 Key 생성을 위한 입력값 검증 (경로 조작 공격 방어)
-	 * @param resourceType 리소스 타입
-	 * @param resourceId 리소스 ID
-	 * @param fileName 파일명
-	 * @throws IllegalArgumentException 유효하지 않은 입력값인 경우
+	 * S3에서 임시 이미지를 최종 위치로 이동
+	 * 
+	 * @param tempS3Key 임시 저장 경로 (tmp/consultation/user-{userId}/{imageType}/{fileName})
+	 * @param finalS3Key 최종 저장 경로 (final/consultation/{consultationId}/{imageType}/{fileName})
 	 */
-	private void validateInputs(String resourceType, Long resourceId, String fileName) {
+	public void moveImageFromTempToFinal(String tempS3Key, String finalS3Key) {
+		try {
+			validateResourceType("consultation");
+			validateResourceType("final");
+
+			// 1. 임시 위치의 파일을 최종 위치로 복사
+			CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
+				.copySource(bucketName + "/" + tempS3Key)
+				.destinationBucket(bucketName)
+				.destinationKey(finalS3Key)
+				.build();
+
+			s3Client.copyObject(copyObjectRequest);
+
+			// 2. 임시 위치의 파일 삭제
+			DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+				.bucket(bucketName)
+				.key(tempS3Key)
+				.build();
+
+			s3Client.deleteObject(deleteObjectRequest);
+
+			log.info("S3 이미지 이동 완료 - from: {}, to: {}", tempS3Key, finalS3Key);
+		} catch (Exception e) {
+			log.error("S3 이미지 이동 실패 - tempS3Key: {}, finalS3Key: {}", tempS3Key, finalS3Key, e);
+			throw new RuntimeException("S3 이미지 이동 중 오류가 발생했습니다", e);
+		}
+	}
+
+	/**
+	 * 현재 로그인한 사용자 ID 가져오기
+	 */
+	private Long getCurrentUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !(authentication.getPrincipal() instanceof Long)) {
+			throw new IllegalArgumentException("사용자 정보를 찾을 수 없습니다.");
+		}
+		return (Long) authentication.getPrincipal();
+	}
+
+	/**
+	 * 리소스 타입 검증
+	 */
+	private void validateResourceType(String resourceType) {
 		if (resourceType == null || resourceType.trim().isEmpty()) {
 			throw new IllegalArgumentException("리소스 타입은 필수입니다.");
 		}
-		if (resourceType.contains("/") || resourceType.contains("\\") || resourceType.contains("..")) {
-			throw new IllegalArgumentException("유효하지 않은 리소스 타입입니다.");
+		if (!resourceType.matches("^[a-z]+$")) {
+			throw new IllegalArgumentException("리소스 타입은 영문 소문자만 허용됩니다.");
 		}
+	}
 
-		if (resourceId == null || resourceId <= 0) {
-			throw new IllegalArgumentException("유효하지 않은 리소스 ID입니다.");
+	/**
+	 * 이미지 타입 검증
+	 */
+	private void validateImageType(String imageType) {
+		if (imageType == null || imageType.trim().isEmpty()) {
+			throw new IllegalArgumentException("이미지 타입은 필수입니다.");
 		}
+		if (!imageType.matches("^[a-z0-9\\-]+$")) {
+			throw new IllegalArgumentException("이미지 타입은 영문 소문자, 숫자, 하이픈만 허용됩니다.");
+		}
+	}
 
+	/**
+	 * 파일명 검증 (경로 조작 공격 방어, 확장자 검증)
+	 */
+	private void validateFileName(String fileName) {
 		if (fileName == null || fileName.trim().isEmpty()) {
 			throw new IllegalArgumentException("파일명은 필수입니다.");
 		}
 		if (fileName.contains("..") || fileName.startsWith("/") || fileName.startsWith("\\")) {
 			throw new IllegalArgumentException("파일명에 경로 조작 문자를 포함할 수 없습니다.");
 		}
+		
+		// 파일 확장자 검증 (이미지 파일만 허용)
+		String lowerFileName = fileName.toLowerCase();
+		if (!lowerFileName.matches(".*\\.(jpg|jpeg|png|gif|webp)$")) {
+			throw new IllegalArgumentException("이미지 파일만 업로드 가능합니다 (jpg, jpeg, png, gif, webp)");
+		}
+	}
+
+	// Response DTO
+	@lombok.Getter
+	@lombok.Builder
+	public static class GeneratePresignedUrlResponse {
+		private String s3Key;
+		private String uploadUrl;
+		private String downloadUrl;
+		private Long expiresIn;
 	}
 }
 

--- a/src/main/java/com/ceos/menual/domain/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/controller/AdminReservationController.java
@@ -1,0 +1,47 @@
+package com.ceos.menual.domain.reservation.controller;
+
+import com.ceos.menual.domain.common.dto.response.CommonResponse;
+import com.ceos.menual.domain.reservation.dto.request.CompletePaymentRequestDTO;
+import com.ceos.menual.domain.reservation.dto.response.CompletePaymentResponseDTO;
+import com.ceos.menual.domain.reservation.service.ReservationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/reservations")
+@RequiredArgsConstructor
+@Tag(name = "관리자 예약 API", description = "관리자 권한이 필요한 예약 관련 엔드포인트")
+public class AdminReservationController {
+
+    private final ReservationService reservationService;
+
+    /**
+     * 관리자: 결제 확인 및 Consultation 생성 API
+     * 사용자가 은행 송금으로 입금한 후, 관리자가 확인하면 호출합니다.
+     */
+    @Operation(
+            summary = "결제 확인",
+            description = "사용자의 은행 송금을 확인하고 상담(Consultation)을 생성합니다."
+    )
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/{reservationId}/payment/confirm")
+    public ResponseEntity<CommonResponse<CompletePaymentResponseDTO>> confirmPaymentByAdmin(
+            @Parameter(description = "예약 ID", required = true, example = "1")
+            @PathVariable Long reservationId,
+
+            @Valid @RequestBody CompletePaymentRequestDTO request
+    ) {
+        CompletePaymentResponseDTO response = reservationService.confirmPaymentByAdmin(
+                reservationId,
+                request
+        );
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+}
+

--- a/src/main/java/com/ceos/menual/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/controller/ReservationController.java
@@ -2,9 +2,11 @@ package com.ceos.menual.domain.reservation.controller;
 
 import com.ceos.menual.domain.common.dto.response.CommonResponse;
 import com.ceos.menual.domain.reservation.dto.request.CreateTempReservationRequestDTO;
+import com.ceos.menual.domain.reservation.dto.request.UpdateReservationConcernRequestDTO;
 import com.ceos.menual.domain.reservation.dto.response.AvailableDatesResponseDTO;
 import com.ceos.menual.domain.reservation.dto.response.AvailableTimesResponseDTO;
 import com.ceos.menual.domain.reservation.dto.response.TempReservationResponseDTO;
+import com.ceos.menual.domain.reservation.dto.response.UpdateReservationConcernResponseDTO;
 import com.ceos.menual.domain.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -80,6 +82,30 @@ public class ReservationController {
             @Valid @RequestBody CreateTempReservationRequestDTO request
     ) {
         TempReservationResponseDTO response = reservationService.createTempReservation(userId, request);
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+    /**
+     * 예약 고민지(concernJson) 업데이트 API
+     */
+    @Operation(
+            summary = "예약 고민지 업데이트",
+            description = "예약에 고민지(이미지, 추구미, 상담 목적)를 작성하여 저장합니다."
+    )
+    @PutMapping("/{reservationId}/concern")
+    public ResponseEntity<CommonResponse<UpdateReservationConcernResponseDTO>> updateReservationConcern(
+            @Parameter(description = "예약 ID", required = true, example = "1")
+            @PathVariable Long reservationId,
+
+            @AuthenticationPrincipal Long userId,
+
+            @Valid @RequestBody UpdateReservationConcernRequestDTO request
+    ) {
+        UpdateReservationConcernResponseDTO response = reservationService.updateReservationConcern(
+                reservationId,
+                userId,
+                request
+        );
         return ResponseEntity.ok(CommonResponse.success(response));
     }
 }

--- a/src/main/java/com/ceos/menual/domain/reservation/dto/ConcernJsonDTO.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/dto/ConcernJsonDTO.java
@@ -1,0 +1,33 @@
+package com.ceos.menual.domain.reservation.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "고민지 JSON 구조")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConcernJsonDTO {
+
+    @Schema(description = "S3 이미지 키 목록 (tmp 또는 final 폴더의 이미지 경로)", example = "[\"tmp/hairstyle.jpg\", \"tmp/front.jpg\", \"tmp/favorite/1.jpg\", \"tmp/favorite/2.jpg\", \"tmp/purpose/1.jpg\"]")
+    @JsonProperty("imageKeys")
+    private List<String> imageKeys;
+
+    @Schema(description = "추구미 (원하는 스타일 설명)", example = "자연스럽고 볼륨감 있는 스타일을 원합니다")
+    @JsonProperty("desiredStyle")
+    private String desiredStyle;
+
+    @Schema(description = "상담 목적 (상담 목표 및 고민사항)", example = "현재 머리가 손상되어 있고 매직이 필요합니다")
+    @JsonProperty("consultationPurpose")
+    private String consultationPurpose;
+}
+
+
+

--- a/src/main/java/com/ceos/menual/domain/reservation/dto/request/CompletePaymentRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/dto/request/CompletePaymentRequestDTO.java
@@ -1,0 +1,15 @@
+package com.ceos.menual.domain.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Schema(description = "관리자: 결제 확인 요청 (Consultation 생성)")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CompletePaymentRequestDTO {
+    // 결제 확인에 필요한 추가 정보 없음
+}
+

--- a/src/main/java/com/ceos/menual/domain/reservation/dto/request/UpdateReservationConcernRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/dto/request/UpdateReservationConcernRequestDTO.java
@@ -1,0 +1,32 @@
+package com.ceos.menual.domain.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Schema(description = "고민지(concernJson) 업데이트 요청")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateReservationConcernRequestDTO {
+
+    @Schema(description = "S3 이미지 키 목록 (tmp 폴더의 이미지 경로)", example = "[\"tmp/hairstyle.jpg\", \"tmp/front.jpg\", \"tmp/favorite/1.jpg\", \"tmp/favorite/2.jpg\", \"tmp/purpose/1.jpg\"]")
+    @NotEmpty(message = "최소 1개 이상의 이미지 키를 포함해야 합니다")
+    private List<String> imageKeys;
+
+    @Schema(description = "추구미 (원하는 스타일 설명)", example = "자연스럽고 볼륨감 있는 스타일을 원합니다", required = true)
+    @NotNull(message = "추구미는 필수입니다")
+    private String desiredStyle;
+
+    @Schema(description = "상담 목적 (상담 목표 및 고민사항)", example = "현재 머리가 손상되어 있고 매직이 필요합니다", required = true)
+    @NotNull(message = "상담 목적은 필수입니다")
+    private String consultationPurpose;
+}
+
+
+

--- a/src/main/java/com/ceos/menual/domain/reservation/dto/request/UpdateReservationConcernRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/dto/request/UpdateReservationConcernRequestDTO.java
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 public class UpdateReservationConcernRequestDTO {
 
-    @Schema(description = "S3 이미지 키 목록 (tmp 폴더의 이미지 경로)", example = "[\"tmp/hairstyle.jpg\", \"tmp/front.jpg\", \"tmp/favorite/1.jpg\", \"tmp/favorite/2.jpg\", \"tmp/purpose/1.jpg\"]")
+    @Schema(description = "S3 이미지 키 목록 (임시 저장 경로: tmp/{resourceType}/user-{userId}/{imageType}/{fileName})", example = "[\"tmp/consultation/user-123/purpose/1.jpg\", \"tmp/consultation/user-123/favorite/2.jpg\", \"tmp/consultation/user-123/favorite/3.jpg\"]")
     @NotEmpty(message = "최소 1개 이상의 이미지 키를 포함해야 합니다")
     private List<String> imageKeys;
 

--- a/src/main/java/com/ceos/menual/domain/reservation/dto/response/CompletePaymentResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/dto/response/CompletePaymentResponseDTO.java
@@ -1,0 +1,48 @@
+package com.ceos.menual.domain.reservation.dto.response;
+
+import com.ceos.menual.entity.Consultation;
+import com.ceos.menual.entity.enums.ConsultationStatus;
+import com.ceos.menual.entity.enums.ConsultationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "결제 완료 응답 (Consultation 생성됨)")
+@Getter
+@Builder
+public class CompletePaymentResponseDTO {
+
+    @Schema(description = "상담 ID", example = "1")
+    private Long consultationId;
+
+    @Schema(description = "예약 ID", example = "1")
+    private Long reservationId;
+
+    @Schema(description = "상담 유형", example = "VIDEO")
+    private ConsultationType type;
+
+    @Schema(description = "상담 상태", example = "SCHEDULED")
+    private ConsultationStatus status;
+
+    @Schema(description = "상담 예정 시간", example = "2026-01-28T11:30:00")
+    private LocalDateTime scheduleTime;
+
+    @Schema(description = "메시지", example = "결제가 완료되었으며 상담이 생성되었습니다")
+    private String message;
+
+    public static CompletePaymentResponseDTO from(Consultation consultation, Long reservationId) {
+        return CompletePaymentResponseDTO.builder()
+                .consultationId(consultation.getId())
+                .reservationId(reservationId)
+                .type(consultation.getType())
+                .status(consultation.getStatus())
+                .scheduleTime(consultation.getScheduleTime())
+                .message("결제가 완료되었으며 상담이 생성되었습니다")
+                .build();
+    }
+}
+
+
+

--- a/src/main/java/com/ceos/menual/domain/reservation/dto/response/CompletePaymentResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/dto/response/CompletePaymentResponseDTO.java
@@ -23,7 +23,7 @@ public class CompletePaymentResponseDTO {
     @Schema(description = "상담 유형", example = "VIDEO")
     private ConsultationType type;
 
-    @Schema(description = "상담 상태", example = "SCHEDULED")
+    @Schema(description = "상담 상태", example = "READY")
     private ConsultationStatus status;
 
     @Schema(description = "상담 예정 시간", example = "2026-01-28T11:30:00")

--- a/src/main/java/com/ceos/menual/domain/reservation/dto/response/UpdateReservationConcernResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/dto/response/UpdateReservationConcernResponseDTO.java
@@ -1,0 +1,33 @@
+package com.ceos.menual.domain.reservation.dto.response;
+
+import com.ceos.menual.domain.reservation.dto.ConcernJsonDTO;
+import com.ceos.menual.entity.Reservation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "예약 고민지 업데이트 응답")
+@Getter
+@Builder
+public class UpdateReservationConcernResponseDTO {
+
+    @Schema(description = "예약 ID", example = "1")
+    private Long reservationId;
+
+    @Schema(description = "업데이트된 고민지")
+    private ConcernJsonDTO concern;
+
+    @Schema(description = "성공 메시지", example = "고민지가 성공적으로 저장되었습니다")
+    private String message;
+
+    public static UpdateReservationConcernResponseDTO from(Reservation reservation, ConcernJsonDTO concernJson) {
+        return UpdateReservationConcernResponseDTO.builder()
+                .reservationId(reservation.getId())
+                .concern(concernJson)
+                .message("고민지가 성공적으로 저장되었습니다")
+                .build();
+    }
+}
+
+
+

--- a/src/main/java/com/ceos/menual/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/exception/ReservationErrorCode.java
@@ -18,7 +18,10 @@ public enum ReservationErrorCode implements ResultCode {
     EXPERT_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, 4007, "전문가 프로필이 존재하지 않습니다."),
     GENERAL_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, 4008, "일반 회원 프로필이 존재하지 않습니다."),
     CONSULTATION_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, 4009, "해당 전문가가 제공하지 않는 상담 유형입니다."),
-    INVALID_PRICE(HttpStatus.BAD_REQUEST, 4010, "잘못된 가격입니다.");
+    INVALID_PRICE(HttpStatus.BAD_REQUEST, 4010, "잘못된 가격입니다."),
+    UNAUTHORIZED_RESERVATION_ACCESS(HttpStatus.FORBIDDEN, 4011, "해당 예약에 대한 접근 권한이 없습니다."),
+    CONCERN_JSON_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 4012, "고민지 JSON 변환 중 오류가 발생했습니다."),
+    INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, 4013, "유효하지 않은 예약 상태입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/ceos/menual/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/exception/ReservationErrorCode.java
@@ -21,7 +21,8 @@ public enum ReservationErrorCode implements ResultCode {
     INVALID_PRICE(HttpStatus.BAD_REQUEST, 4010, "잘못된 가격입니다."),
     UNAUTHORIZED_RESERVATION_ACCESS(HttpStatus.FORBIDDEN, 4011, "해당 예약에 대한 접근 권한이 없습니다."),
     CONCERN_JSON_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 4012, "고민지 JSON 변환 중 오류가 발생했습니다."),
-    INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, 4013, "유효하지 않은 예약 상태입니다.");
+    INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, 4013, "유효하지 않은 예약 상태입니다."),
+    INVALID_IMAGE_KEY_FORMAT(HttpStatus.BAD_REQUEST, 4014, "잘못된 이미지 키 형식입니다. 형식: tmp/consultation/user-{userId}/{imageType}/{fileName}");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
@@ -31,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -387,6 +388,85 @@ public class ReservationService {
     }
 
     /**
+     * 이미지 키 형식 검증
+     * 
+     * 기대 형식: tmp/consultation/user-{userId}/{imageType}/{fileName}
+     * 예: tmp/consultation/user-123/purpose/1.jpg
+     * 
+     * @param imageKeys 검증할 이미지 키 목록
+     * @return 잘못된 형식의 이미지 키 목록 (비어있으면 모두 유효)
+     */
+    private List<String> validateImageKeysFormat(List<String> imageKeys) {
+        List<String> invalidKeys = new ArrayList<>();
+
+        for (String imageKey : imageKeys) {
+            if (!isValidImageKeyFormat(imageKey)) {
+                invalidKeys.add(imageKey);
+            }
+        }
+
+        return invalidKeys;
+    }
+
+    /**
+     * 단일 이미지 키의 형식이 유효한지 확인
+     * 
+     * @param imageKey 검증할 이미지 키
+     * @return 유효하면 true, 아니면 false
+     */
+    private boolean isValidImageKeyFormat(String imageKey) {
+        // null 또는 빈 문자열 체크
+        if (imageKey == null || imageKey.trim().isEmpty()) {
+            log.warn("빈 이미지 키");
+            return false;
+        }
+
+        // 경로 분석
+        String[] parts = imageKey.split("/");
+
+        // 기대 형식: tmp/consultation/user-{userId}/{imageType}/{fileName}
+        // parts[0] = "tmp"
+        // parts[1] = "consultation"
+        // parts[2] = "user-{userId}"
+        // parts[3] = "{imageType}"
+        // parts[4] = "{fileName}"
+        if (parts.length < 5) {
+            log.warn("이미지 키 구조 불일치 - imageKey: {}, partCount: {}", imageKey, parts.length);
+            return false;
+        }
+
+        // 기본 경로 검증
+        if (!"tmp".equals(parts[0])) {
+            log.warn("첫 번째 경로 컴포넌트가 'tmp'가 아님 - imageKey: {}", imageKey);
+            return false;
+        }
+
+        if (!"consultation".equals(parts[1])) {
+            log.warn("두 번째 경로 컴포넌트가 'consultation'이 아님 - imageKey: {}", imageKey);
+            return false;
+        }
+
+        if (!parts[2].startsWith("user-")) {
+            log.warn("세 번째 경로 컴포넌트가 'user-' 형식이 아님 - imageKey: {}, userPart: {}", imageKey, parts[2]);
+            return false;
+        }
+
+        // imageType 검증 (비어있으면 안됨)
+        if (parts[3] == null || parts[3].trim().isEmpty()) {
+            log.warn("imageType이 비어있음 - imageKey: {}", imageKey);
+            return false;
+        }
+
+        // fileName 검증 (비어있으면 안됨)
+        if (parts[4] == null || parts[4].trim().isEmpty()) {
+            log.warn("fileName이 비어있음 - imageKey: {}", imageKey);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * S3 임시 저장된 이미지를 최종 위치로 이동
      * tmp/consultation/user-{userId}/{imageType}/{fileName}
      *     → final/consultation/{consultationId}/{imageType}/{fileName}
@@ -411,14 +491,25 @@ public class ReservationService {
             Long userId = reservation.getGeneralProfile().getUser().getId();
             Long consultationId = consultation.getId();
 
-            // 각 이미지를 최종 위치로 이동
+            // 사전 검증: 모든 이미지 키가 유효한 형식인지 확인 (이동 작업 전)
+            List<String> invalidImageKeys = validateImageKeysFormat(imageKeys);
+            if (!invalidImageKeys.isEmpty()) {
+                log.error("잘못된 이미지 키 형식 발견 - 이동 작업 중단 - consultationId: {}, invalidKeys: {}", 
+                    consultationId, invalidImageKeys);
+                throw new GlobalException(ReservationErrorCode.INVALID_IMAGE_KEY_FORMAT);
+            }
+
+            // 모든 키가 유효한 경우에만 이미지 이동 시작
             for (String imageKey : imageKeys) {
                 // imageKey 형식: tmp/consultation/user-{userId}/{imageType}/{fileName}
                 // 이 경로에서 imageType과 fileName을 추출
                 String[] parts = imageKey.split("/");
+                
+                // 사전 검증에서 이미 확인했지만, 방어적 프로그래밍을 위해 재확인
                 if (parts.length < 5) {
-                    log.warn("잘못된 이미지 키 형식: {}", imageKey);
-                    continue;
+                    log.error("예상치 못한 이미지 키 형식 - consultationId: {}, imageKey: {}", 
+                        consultationId, imageKey);
+                    throw new GlobalException(ReservationErrorCode.INVALID_IMAGE_KEY_FORMAT);
                 }
 
                 String imageType = parts[3];  // hairstyle, favorite, purpose 등
@@ -435,12 +526,11 @@ public class ReservationService {
             }
 
             // ConcernJsonDTO의 imageKeys를 최종 경로로 업데이트
+            // 모든 이미지 키는 이미 검증되었으므로 안전하게 변환
             List<String> finalImageKeys = imageKeys.stream()
                     .map(imageKey -> {
                         String[] parts = imageKey.split("/");
-                        if (parts.length < 5) {
-                            return imageKey;
-                        }
+                        // 사전 검증에서 이미 확인했으므로 parts.length >= 5 보장
                         String imageType = parts[3];
                         String fileName = parts[4];
                         return String.format("final/consultation/%d/%s/%s", 

--- a/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
@@ -1,19 +1,28 @@
 package com.ceos.menual.domain.reservation.service;
 
+import com.ceos.menual.domain.common.service.S3PresignedUrlService;
+import com.ceos.menual.domain.consultation.repository.ConsultationRepository;
+import com.ceos.menual.domain.reservation.dto.ConcernJsonDTO;
+import com.ceos.menual.domain.reservation.dto.request.CompletePaymentRequestDTO;
 import com.ceos.menual.domain.reservation.dto.request.CreateTempReservationRequestDTO;
+import com.ceos.menual.domain.reservation.dto.request.UpdateReservationConcernRequestDTO;
 import com.ceos.menual.domain.reservation.dto.response.AvailableDatesResponseDTO;
 import com.ceos.menual.domain.reservation.dto.response.AvailableTimesResponseDTO;
+import com.ceos.menual.domain.reservation.dto.response.CompletePaymentResponseDTO;
 import com.ceos.menual.domain.reservation.dto.response.TempReservationResponseDTO;
+import com.ceos.menual.domain.reservation.dto.response.UpdateReservationConcernResponseDTO;
 import com.ceos.menual.domain.reservation.exception.ReservationErrorCode;
 import com.ceos.menual.domain.reservation.repository.AvailableScheduleRepository;
 import com.ceos.menual.domain.reservation.repository.ReservationRepository;
 import com.ceos.menual.domain.user.exception.UserErrorCode;
 import com.ceos.menual.domain.user.repository.UserRepository;
 import com.ceos.menual.entity.*;
+import com.ceos.menual.entity.enums.ConsultationStatus;
 import com.ceos.menual.entity.enums.ConsultationType;
 import com.ceos.menual.entity.enums.ReservationStatus;
 import com.ceos.menual.entity.enums.UserType;
 import com.ceos.menual.global.exception.GlobalException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,11 +43,102 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final AvailableScheduleRepository availableScheduleRepository;
+    private final ConsultationRepository consultationRepository;
+    private final ObjectMapper objectMapper;
+    private final S3PresignedUrlService s3PresignedUrlService;
 
     private static final List<ReservationStatus> ACTIVE_RESERVATION_STATUSES =
             List.of(ReservationStatus.UNPAID, ReservationStatus.PAID);
 
     private static final int PAYMENT_WAITING_MINUTES = 60; // 60분 후에 만료
+
+    /**
+     * 관리자: 결제 확인 및 Consultation 생성
+     * 사용자가 은행 송금으로 입금한 후, 관리자가 확인하면 호출
+     * 
+     * 동시에 S3의 임시 저장 이미지를 최종 저장 위치로 이동
+     * tmp/consultation/user-{userId}/{imageType}/{fileName}
+     *     → final/consultation/{consultationId}/{imageType}/{fileName}
+     */
+    @Transactional
+    public CompletePaymentResponseDTO confirmPaymentByAdmin(
+            Long reservationId,
+            CompletePaymentRequestDTO requestDTO
+    ) {
+        log.info("관리자 결제 확인 및 상담 생성 시작 - reservationId: {}", reservationId);
+
+        // 예약 조회
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new GlobalException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        // 예약 상태 검증 (UNPAID 상태만 결제 가능)
+        if (reservation.getReservationStatus() != ReservationStatus.UNPAID) {
+            throw new GlobalException(ReservationErrorCode.INVALID_RESERVATION_STATUS);
+        }
+
+        // Consultation 생성
+        Consultation consultation = Consultation.builder()
+                .expertProfile(reservation.getExpertProfile())
+                .generalProfile(reservation.getGeneralProfile())
+                .type(reservation.getConsultationType())
+                .status(ConsultationStatus.READY) // 초기 상태: 준비됨 (결제 확인 후)
+                .scheduleTime(reservation.getScheduledDateTime())
+                .reviewWritten(false)
+                .build();
+
+        Consultation savedConsultation = consultationRepository.save(consultation);
+
+        // 예약 상태를 PAID로 변경하고 consultation과 연결
+        reservation.updateStatusToPaid(savedConsultation);
+
+        // S3 임시 이미지를 최종 위치로 이동
+        moveImagesToFinalLocation(reservation, savedConsultation);
+
+        log.info("관리자 결제 확인 및 상담 생성 완료 - reservationId: {}, consultationId: {}",
+                reservationId, savedConsultation.getId());
+
+        return CompletePaymentResponseDTO.from(savedConsultation, reservationId);
+    }
+
+    /**
+     * 예약의 고민지(concernJson) 업데이트
+     */
+    @Transactional
+    public UpdateReservationConcernResponseDTO updateReservationConcern(
+            Long reservationId,
+            Long userId,
+            UpdateReservationConcernRequestDTO requestDTO
+    ) {
+        log.info("고민지 업데이트 시작 - reservationId: {}, userId: {}", reservationId, userId);
+
+        // 예약 조회
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new GlobalException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        // 예약 소유자 검증 (예약한 일반 회원과 현재 사용자가 동일한지 확인)
+        if (!reservation.getGeneralProfile().getUser().getId().equals(userId)) {
+            throw new GlobalException(ReservationErrorCode.UNAUTHORIZED_RESERVATION_ACCESS);
+        }
+
+        // 고민지 JSON 생성
+        ConcernJsonDTO concernJson = ConcernJsonDTO.builder()
+                .imageKeys(requestDTO.getImageKeys())
+                .desiredStyle(requestDTO.getDesiredStyle())
+                .consultationPurpose(requestDTO.getConsultationPurpose())
+                .build();
+
+        // JSON 문자열로 변환
+        try {
+            String concernJsonString = objectMapper.writeValueAsString(concernJson);
+            reservation.updateConcerns(concernJsonString);
+            log.info("고민지 업데이트 완료 - reservationId: {}", reservationId);
+        } catch (Exception e) {
+            log.error("고민지 JSON 변환 실패 - reservationId: {}", reservationId, e);
+            throw new GlobalException(ReservationErrorCode.CONCERN_JSON_CONVERSION_ERROR);
+        }
+
+        return UpdateReservationConcernResponseDTO.from(reservation, concernJson);
+    }
 
     @Transactional
     public TempReservationResponseDTO createTempReservation(
@@ -284,5 +384,85 @@ public class ReservationService {
                     LocalDateTime dateTime = date.atTime(schedule.getAvailableTime());
                     return dateTime.isAfter(now) && !bookedTimes.contains(dateTime);
                 });
+    }
+
+    /**
+     * S3 임시 저장된 이미지를 최종 위치로 이동
+     * tmp/consultation/user-{userId}/{imageType}/{fileName}
+     *     → final/consultation/{consultationId}/{imageType}/{fileName}
+     */
+    private void moveImagesToFinalLocation(Reservation reservation, Consultation consultation) {
+        try {
+            // 고민지 JSON 파싱
+            String concernsJsonString = reservation.getConcernsJson();
+            if (concernsJsonString == null || concernsJsonString.isEmpty()) {
+                log.info("이동할 이미지가 없음 - consultationId: {}", consultation.getId());
+                return;
+            }
+
+            ConcernJsonDTO concernJson = objectMapper.readValue(concernsJsonString, ConcernJsonDTO.class);
+            List<String> imageKeys = concernJson.getImageKeys();
+
+            if (imageKeys == null || imageKeys.isEmpty()) {
+                log.info("이미지 키가 없음 - consultationId: {}", consultation.getId());
+                return;
+            }
+
+            Long userId = reservation.getGeneralProfile().getUser().getId();
+            Long consultationId = consultation.getId();
+
+            // 각 이미지를 최종 위치로 이동
+            for (String imageKey : imageKeys) {
+                // imageKey 형식: tmp/consultation/user-{userId}/{imageType}/{fileName}
+                // 이 경로에서 imageType과 fileName을 추출
+                String[] parts = imageKey.split("/");
+                if (parts.length < 5) {
+                    log.warn("잘못된 이미지 키 형식: {}", imageKey);
+                    continue;
+                }
+
+                String imageType = parts[3];  // hairstyle, favorite, purpose 등
+                String fileName = parts[4];   // 파일명
+
+                // 최종 경로 생성: final/consultation/{consultationId}/{imageType}/{fileName}
+                String finalS3Key = String.format("final/consultation/%d/%s/%s", 
+                    consultationId, imageType, fileName);
+
+                // S3에서 이미지 이동
+                s3PresignedUrlService.moveImageFromTempToFinal(imageKey, finalS3Key);
+
+                log.info("이미지 이동 완료 - from: {}, to: {}", imageKey, finalS3Key);
+            }
+
+            // ConcernJsonDTO의 imageKeys를 최종 경로로 업데이트
+            List<String> finalImageKeys = imageKeys.stream()
+                    .map(imageKey -> {
+                        String[] parts = imageKey.split("/");
+                        if (parts.length < 5) {
+                            return imageKey;
+                        }
+                        String imageType = parts[3];
+                        String fileName = parts[4];
+                        return String.format("final/consultation/%d/%s/%s", 
+                            consultationId, imageType, fileName);
+                    })
+                    .collect(Collectors.toList());
+
+            concernJson = ConcernJsonDTO.builder()
+                    .imageKeys(finalImageKeys)
+                    .desiredStyle(concernJson.getDesiredStyle())
+                    .consultationPurpose(concernJson.getConsultationPurpose())
+                    .build();
+
+            // 업데이트된 JSON으로 저장
+            String updatedConcernsJsonString = objectMapper.writeValueAsString(concernJson);
+            reservation.updateConcerns(updatedConcernsJsonString);
+
+            log.info("고민지 이미지 경로 업데이트 완료 - consultationId: {}", consultationId);
+
+        } catch (Exception e) {
+            log.error("S3 이미지 이동 중 오류 발생 - consultationId: {}", consultation.getId(), e);
+            throw new GlobalException(ReservationErrorCode.CONCERN_JSON_CONVERSION_ERROR);
+        }
     }
 }

--- a/src/main/java/com/ceos/menual/entity/Consultation.java
+++ b/src/main/java/com/ceos/menual/entity/Consultation.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import com.ceos.menual.entity.enums.ConsultationStatus;
 import com.ceos.menual.entity.enums.ConsultationType;
-import com.ceos.menual.entity.enums.PaymentStatus;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -47,23 +46,16 @@ public class Consultation extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private ConsultationStatus status;
 
+	// 실제 상담 일정
 	private LocalDateTime scheduleTime;
 
-	private Integer price;
-
-	@Enumerated(EnumType.STRING)
-	private PaymentStatus paymentStatus;
-
-	//화상상담 관련
+	// 화상 상담 관련
 	private LocalDateTime videoStartTime;
 	private LocalDateTime videoEndTime;
 	private Integer durationMinutes;
 	private String videoLink;
 
-	//고민지 관련 추후 작성 예정
-
 	//솔루션 관련
-	private String solutionPdfUrl;
 	private LocalDateTime solutionSubmittedAt;
 
 	private Boolean reviewWritten;

--- a/src/main/java/com/ceos/menual/entity/Reservation.java
+++ b/src/main/java/com/ceos/menual/entity/Reservation.java
@@ -38,12 +38,9 @@ public class Reservation extends BaseEntity {
     @Column(name = "consultation_type", nullable = false, length = 20)
     private ConsultationType consultationType;
 
+    // 예약 일정
     @Column(name = "scheduled_date_time")
     private LocalDateTime scheduledDateTime;
-
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "concerns_json", columnDefinition = "json")
-    private String concernsJson;
 
     @Column(nullable = false)
     private Integer price;
@@ -55,9 +52,15 @@ public class Reservation extends BaseEntity {
     @Column(name = "expires_at")
     private LocalDateTime expiresAt;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    // 결제 완료 후 생성
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "consultation_id")
     private Consultation consultation;
+
+    // 고민 입력
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "concerns_json", columnDefinition = "json")
+    private String concernsJson;
 
     // 비즈니스 메서드
     public void updateConcerns(String concernsJson) {

--- a/src/main/java/com/ceos/menual/entity/enums/PaymentStatus.java
+++ b/src/main/java/com/ceos/menual/entity/enums/PaymentStatus.java
@@ -1,7 +1,0 @@
-package com.ceos.menual.entity.enums;
-
-public enum PaymentStatus {
-	PAID,
-	REFUNDED,
-	FAILED
-}

--- a/src/main/java/com/ceos/menual/entity/enums/UserType.java
+++ b/src/main/java/com/ceos/menual/entity/enums/UserType.java
@@ -3,5 +3,6 @@ package com.ceos.menual.entity.enums;
 public enum UserType {
     MEMBER,
     TMP_USER,
-    EXPERT
+    EXPERT,
+    ADMIN
 }

--- a/src/main/java/com/ceos/menual/global/config/SecurityConfig.java
+++ b/src/main/java/com/ceos/menual/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.ceos.menual.global.config.jwt.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -20,6 +21,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/ceos/menual/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ceos/menual/global/config/jwt/JwtAuthenticationFilter.java
@@ -52,7 +52,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         Long userId = jwtValidator.getUserIdFromToken(accessToken);
                         // 인증 객체를 생성해 SecurityContext에 저장
                         // 이후 컨트롤러에서 @AuthenticationPrincipal 등으로 접근 가능
-                        setAuthentication(request, userId);
+                        setAuthentication(request, userId, accessToken);
                     }
                 }
             } catch (Exception e) {
@@ -66,11 +66,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     // SecurityContext에 인증 정보를 등록하는 메서드
-    private void setAuthentication(HttpServletRequest request, Long userId) {
+    private void setAuthentication(HttpServletRequest request, Long userId, String accessToken) {
+        // 토큰에서 UserType 추출
+        String userType = jwtValidator.getUserTypeFromToken(accessToken);
+        
+        // UserType에 따라 권한 설정
+        String authority = "ROLE_USER"; // 기본값
+        if ("ADMIN".equals(userType)) {
+            authority = "ROLE_ADMIN";
+        } else if ("EXPERT".equals(userType)) {
+            authority = "ROLE_EXPERT";
+        }
+        
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                 userId,
                 null,
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+                Collections.singletonList(new SimpleGrantedAuthority(authority))
         );
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/ceos/menual/global/config/jwt/JwtProvider.java
+++ b/src/main/java/com/ceos/menual/global/config/jwt/JwtProvider.java
@@ -41,13 +41,14 @@ public class JwtProvider {
     }
 
     // Access Token 생성
-    public String createAccessToken(Long userId, String email) {
+    public String createAccessToken(Long userId, String email, String userType) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + accessTokenValidity);
 
         return Jwts.builder()
                 .subject(userId.toString())
                 .claim("email", email)
+                .claim("userType", userType)
                 .claim("type", "access")
                 .issuedAt(now)
                 .expiration(validity)

--- a/src/main/java/com/ceos/menual/global/config/jwt/JwtValidator.java
+++ b/src/main/java/com/ceos/menual/global/config/jwt/JwtValidator.java
@@ -61,5 +61,14 @@ public class JwtValidator {
                 .get("type", String.class);
     }
 
+    // 사용자 타입 추출
+    public String getUserTypeFromToken(String token) {
+        return Jwts.parser()
+                .verifyWith(getKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("userType", String.class);
+    }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,16 @@ aws:
     region: ${AWS_REGION}
     access-key: ${AWS_ACCESS_KEY_ID}
     secret-key: ${AWS_SECRET_ACCESS_KEY}
+    cleanup:
+      # 삭제 실패 시 최대 재시도 횟수
+      max-retries: 3
+      # 재시도 간 대기 시간 (밀리초)
+      retry-interval-ms: 1000
+      # 미처리 작업 재시도 스케줄러 실행 간격 (밀리초, 기본값: 15분)
+      retry-scheduler-interval: 900000
+      # 스케줄러 초기 지연 시간 (밀리초)
+      initial-delay: 60000
+      # 오래된 완료 작업 정리 주기 (cron 표현식, 기본값: 매일 오전 3시)
+      old-task-cleanup-cron: "0 0 3 * * *"
+      # 장시간 미처리 작업 모니터링 간격 (밀리초, 기본값: 1시간)
+      stale-task-check-interval: 3600000


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호 (깃허브 이슈 번호를 작성해주세요)
close #69

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. **엔티티 리팩토링**
   - `price`, `paymentStatus`, `solutionPdfUrl` 필드 제거, `PaymentStatus` enum 삭제
   - `Reservation` 엔티티 정리

2. **고민지 업데이트 API**
   - `ConcernJsonDTO`: 고민지 정보
   - 예약자 권한 검증

3. **관리자 결제 확인 및 Consultation 생성**
   - `AdminReservationController`: 관리자용 API 분리
   - S3 임시 이미지(tmp/\~~) → 최종 위치(final/~~) 자동 이동

4. **S3 이미지 관리 시스템**
   - 임시 경로: `tmp/{resourceType}/user-{userId}/{imageType}/{fileName}`
   - 최종 경로: `final/{resourceType}/{resourceId}/{imageType}/{fileName}`
   - S3 이미지 복사 및 삭제 로직

5. **Admin Role-Based Access Control**
   - `UserType.ADMIN` enum 추가
   - JWT에 `userType` claim 포함
   - `@PreAuthorize("hasRole('ADMIN')")` 적용
   - 동적 role 할당: `ROLE_ADMIN`, `ROLE_EXPERT`, `ROLE_USER`

6. **Presigned URL API**
   - 파일 확장자 검증 (jpg, jpeg, png, gif, webp)
   - S3 경로 수정 


## 📷스크린샷 (선택)

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 예약 결제 확인 후 상담을 생성하는 기능 추가
  * 사용자가 예약에 이미지, 희망 스타일, 상담 목적(고민지)을 저장·수정하는 기능 추가
  * S3 업로드/다운로드용 사전 서명 URL 흐름 개선 및 임시→최종 이미지 이동 지원

* **개선 사항**
  * 역할(ADMIN/EXPERT/USER) 기반 접근 제어 강화 및 토큰에 역할 포함
  * 예약에 상담 일정 필드 추가

* **Chores**
  * AWS S3 SDK 버전 변경 및 관련 설정 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->