### PR TITLE
Zoom 연동 api 구현

### DIFF
--- a/src/main/java/com/ceos/menual/domain/expert/api/ZoomOauthClient.java
+++ b/src/main/java/com/ceos/menual/domain/expert/api/ZoomOauthClient.java
@@ -5,15 +5,18 @@ import com.ceos.menual.domain.expert.dto.response.ZoomUserInfoResponseDTO;
 import com.ceos.menual.domain.expert.exception.ZoomErrorCode;
 import com.ceos.menual.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ZoomOauthClient {
 
     private final WebClient zoomAuthWebClient;
@@ -26,10 +29,6 @@ public class ZoomOauthClient {
         String code
     ) {
         try {
-            String basic = Base64.getEncoder().encodeToString(
-                (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8)
-            );
-
             ZoomTokenResponseDTO token = zoomAuthWebClient.post()
                 .uri(uriBuilder -> uriBuilder
                     .path("/oauth/token")
@@ -37,7 +36,7 @@ public class ZoomOauthClient {
                     .queryParam("code", code)
                     .queryParam("redirect_uri", redirectUri)
                     .build())
-                .header("Authorization", "Basic " + basic)
+                .header("Authorization", buildBasicAuthHeader(clientId, clientSecret))
                 .retrieve()
                 .bodyToMono(ZoomTokenResponseDTO.class)
                 .block();
@@ -46,6 +45,13 @@ public class ZoomOauthClient {
                 throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_TOKEN_EXCHANGE_FAILED);
             }
             return token;
+        } catch (WebClientResponseException e) {
+            log.warn(
+                "Zoom OAuth token exchange failed. status={}, body={}",
+                e.getStatusCode(),
+                e.getResponseBodyAsString()
+            );
+            throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_TOKEN_EXCHANGE_FAILED);
         } catch (WebClientRequestException e) {
             throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_TOKEN_EXCHANGE_FAILED);
         }
@@ -57,17 +63,13 @@ public class ZoomOauthClient {
         String refreshToken
     ) {
         try {
-            String basic = Base64.getEncoder().encodeToString(
-                (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8)
-            );
-
             ZoomTokenResponseDTO token = zoomAuthWebClient.post()
                 .uri(uriBuilder -> uriBuilder
                     .path("/oauth/token")
                     .queryParam("grant_type", "refresh_token")
                     .queryParam("refresh_token", refreshToken)
                     .build())
-                .header("Authorization", "Basic " + basic)
+                .header("Authorization", buildBasicAuthHeader(clientId, clientSecret))
                 .retrieve()
                 .bodyToMono(ZoomTokenResponseDTO.class)
                 .block();
@@ -76,9 +78,23 @@ public class ZoomOauthClient {
                 throw new GlobalException(ZoomErrorCode.ZOOM_TOKEN_REFRESH_FAILED);
             }
             return token;
+        } catch (WebClientResponseException e) {
+            log.warn(
+                "Zoom OAuth refresh token failed. status={}, body={}",
+                e.getStatusCode(),
+                e.getResponseBodyAsString()
+            );
+            throw new GlobalException(ZoomErrorCode.ZOOM_TOKEN_REFRESH_FAILED);
         } catch (WebClientRequestException e) {
             throw new GlobalException(ZoomErrorCode.ZOOM_TOKEN_REFRESH_FAILED);
         }
+    }
+
+    private String buildBasicAuthHeader(String clientId, String clientSecret) {
+        String encoded = Base64.getEncoder().encodeToString(
+            (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8)
+        );
+        return "Basic " + encoded;
     }
 
     public ZoomUserInfoResponseDTO getUserInfo(String accessToken) {
@@ -94,6 +110,13 @@ public class ZoomOauthClient {
                 throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_USERINFO_FAILED);
             }
             return userInfo;
+        } catch (WebClientResponseException e) {
+            log.warn(
+                "Zoom OAuth userinfo failed. status={}, body={}",
+                e.getStatusCode(),
+                e.getResponseBodyAsString()
+            );
+            throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_USERINFO_FAILED);
         } catch (WebClientRequestException e) {
             throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_USERINFO_FAILED);
         }

--- a/src/main/java/com/ceos/menual/domain/expert/api/ZoomOauthClient.java
+++ b/src/main/java/com/ceos/menual/domain/expert/api/ZoomOauthClient.java
@@ -1,0 +1,102 @@
+package com.ceos.menual.domain.expert.api;
+
+import com.ceos.menual.domain.expert.dto.response.ZoomTokenResponseDTO;
+import com.ceos.menual.domain.expert.dto.response.ZoomUserInfoResponseDTO;
+import com.ceos.menual.domain.expert.exception.ZoomErrorCode;
+import com.ceos.menual.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+@RequiredArgsConstructor
+public class ZoomOauthClient {
+
+    private final WebClient zoomAuthWebClient;
+    private final WebClient zoomApiWebClient;
+
+    public ZoomTokenResponseDTO exchangeCodeForToken(
+        String clientId,
+        String clientSecret,
+        String redirectUri,
+        String code
+    ) {
+        try {
+            String basic = Base64.getEncoder().encodeToString(
+                (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8)
+            );
+
+            ZoomTokenResponseDTO token = zoomAuthWebClient.post()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/oauth/token")
+                    .queryParam("grant_type", "authorization_code")
+                    .queryParam("code", code)
+                    .queryParam("redirect_uri", redirectUri)
+                    .build())
+                .header("Authorization", "Basic " + basic)
+                .retrieve()
+                .bodyToMono(ZoomTokenResponseDTO.class)
+                .block();
+
+            if (token == null || token.getAccessToken() == null) {
+                throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_TOKEN_EXCHANGE_FAILED);
+            }
+            return token;
+        } catch (WebClientRequestException e) {
+            throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_TOKEN_EXCHANGE_FAILED);
+        }
+    }
+
+    public ZoomTokenResponseDTO refreshAccessToken(
+        String clientId,
+        String clientSecret,
+        String refreshToken
+    ) {
+        try {
+            String basic = Base64.getEncoder().encodeToString(
+                (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8)
+            );
+
+            ZoomTokenResponseDTO token = zoomAuthWebClient.post()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/oauth/token")
+                    .queryParam("grant_type", "refresh_token")
+                    .queryParam("refresh_token", refreshToken)
+                    .build())
+                .header("Authorization", "Basic " + basic)
+                .retrieve()
+                .bodyToMono(ZoomTokenResponseDTO.class)
+                .block();
+
+            if (token == null || token.getAccessToken() == null) {
+                throw new GlobalException(ZoomErrorCode.ZOOM_TOKEN_REFRESH_FAILED);
+            }
+            return token;
+        } catch (WebClientRequestException e) {
+            throw new GlobalException(ZoomErrorCode.ZOOM_TOKEN_REFRESH_FAILED);
+        }
+    }
+
+    public ZoomUserInfoResponseDTO getUserInfo(String accessToken) {
+        try {
+            ZoomUserInfoResponseDTO userInfo = zoomApiWebClient.get()
+                .uri("/v2/users/me")
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(ZoomUserInfoResponseDTO.class)
+                .block();
+
+            if (userInfo == null || userInfo.getId() == null) {
+                throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_USERINFO_FAILED);
+            }
+            return userInfo;
+        } catch (WebClientRequestException e) {
+            throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_USERINFO_FAILED);
+        }
+    }
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/controller/ExpertZoomController.java
+++ b/src/main/java/com/ceos/menual/domain/expert/controller/ExpertZoomController.java
@@ -1,0 +1,110 @@
+package com.ceos.menual.domain.expert.controller;
+
+import com.ceos.menual.domain.common.dto.response.CommonResponse;
+import com.ceos.menual.domain.expert.service.zoom.ZoomOAuthCallbackResult;
+import com.ceos.menual.domain.expert.service.zoom.ZoomOAuthService;
+import com.ceos.menual.domain.expert.service.zoom.ZoomProperties;
+import com.ceos.menual.global.exception.GlobalException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/experts/zoom")
+@RequiredArgsConstructor
+@Tag(name = "전문가 Zoom 연동 API", description = "전문가 Zoom OAuth 연동/콜백 처리")
+public class ExpertZoomController {
+
+    private final ZoomOAuthService zoomOAuthService;
+    private final ZoomProperties zoomProperties;
+
+    @Operation(summary = "Zoom OAuth 연동 시작", description = "Zoom 로그인/권한동의 화면으로 302 리다이렉트합니다.")
+    @PreAuthorize("hasRole('EXPERT')")
+    @GetMapping("/connect")
+    public ResponseEntity<Void> connect(@AuthenticationPrincipal Long userId) {
+        URI authorizeUrl = zoomOAuthService.buildAuthorizeRedirectUrl(userId);
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .header(HttpHeaders.LOCATION, authorizeUrl.toString())
+            .build();
+    }
+
+    @Operation(
+        summary = "Zoom OAuth 콜백",
+        description = "Zoom에서 전달된 code/state를 처리합니다. " +
+            "설정된 success/failure redirect URI가 있으면 302로 프론트로 리다이렉트하고, " +
+            "없으면 기존처럼 JSON으로 결과를 반환합니다."
+    )
+    @GetMapping("/callback")
+    public ResponseEntity<?> callback(
+        @RequestParam String code,
+        @RequestParam String state
+    ) {
+        try {
+            ZoomOAuthCallbackResult result = zoomOAuthService.handleCallback(code, state);
+
+            // 설정된 success redirect URI가 있으면 프론트로 302
+            if (!isBlank(zoomProperties.getSuccessRedirectUri())) {
+                URI target = UriComponentsBuilder
+                    .fromUriString(zoomProperties.getSuccessRedirectUri())
+                    .queryParam("connected", "true")
+                    .build(true)
+                    .toUri();
+
+                return ResponseEntity.status(HttpStatus.FOUND)
+                    .header(HttpHeaders.LOCATION, target.toString())
+                    .build();
+            }
+
+            // 토큰 자체는 응답에 포함하지 않고, 연결 확인에 필요한 정보만 반환
+            return ResponseEntity.ok(CommonResponse.success(
+                new ZoomCallbackPublicResponse(
+                    result.getExpertUserId(),
+                    result.getZoomUserId(),
+                    result.getZoomEmail(),
+                    result.getTokenExpiresAt()
+                )
+            ));
+        } catch (GlobalException e) {
+            // 설정된 failure redirect URI가 있으면 프론트로 302
+            if (!isBlank(zoomProperties.getFailureRedirectUri())) {
+                URI target = UriComponentsBuilder
+                    .fromUriString(zoomProperties.getFailureRedirectUri())
+                    .queryParam("connected", "false")
+                    .queryParam("error", e.getResultCode())
+                    .build(true)
+                    .toUri();
+
+                return ResponseEntity.status(HttpStatus.FOUND)
+                    .header(HttpHeaders.LOCATION, target.toString())
+                    .build();
+            }
+
+            // 기존 동작 유지: 예외는 그대로 전파 (전역 예외 처리에서 응답 생성)
+            throw e;
+        }
+    }
+
+    private record ZoomCallbackPublicResponse(
+        Long expertUserId,
+        String zoomUserId,
+        String zoomEmail,
+        java.time.LocalDateTime tokenExpiresAt
+    ) {}
+
+    private boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/dto/response/ZoomCreateMeetingResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/expert/dto/response/ZoomCreateMeetingResponseDTO.java
@@ -1,0 +1,13 @@
+package com.ceos.menual.domain.expert.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ZoomCreateMeetingResponseDTO {
+    private Long id;
+
+    @JsonProperty("join_url")
+    private String joinUrl;
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/dto/response/ZoomTokenResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/expert/dto/response/ZoomTokenResponseDTO.java
@@ -1,0 +1,17 @@
+package com.ceos.menual.domain.expert.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ZoomTokenResponseDTO {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/dto/response/ZoomUserInfoResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/expert/dto/response/ZoomUserInfoResponseDTO.java
@@ -1,0 +1,10 @@
+package com.ceos.menual.domain.expert.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class ZoomUserInfoResponseDTO {
+    private String id;
+    private String email;
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/exception/ZoomErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/expert/exception/ZoomErrorCode.java
@@ -1,0 +1,24 @@
+package com.ceos.menual.domain.expert.exception;
+
+import com.ceos.menual.global.exception.ResultCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ZoomErrorCode implements ResultCode {
+
+    ZOOM_OAUTH_NOT_CONFIGURED(HttpStatus.INTERNAL_SERVER_ERROR, 7001, "Zoom OAuth 설정이 누락되었습니다."),
+    ZOOM_OAUTH_STATE_INVALID(HttpStatus.BAD_REQUEST, 7002, "유효하지 않은 OAuth state 입니다."),
+    ZOOM_OAUTH_TOKEN_EXCHANGE_FAILED(HttpStatus.BAD_GATEWAY, 7003, "Zoom 토큰 교환에 실패했습니다."),
+    ZOOM_OAUTH_USERINFO_FAILED(HttpStatus.BAD_GATEWAY, 7004, "Zoom 사용자 정보 조회에 실패했습니다."),
+    ZOOM_TOKEN_REFRESH_FAILED(HttpStatus.BAD_GATEWAY, 7005, "Zoom 토큰 갱신에 실패했습니다."),
+    ZOOM_MEETING_CREATE_FAILED(HttpStatus.BAD_GATEWAY, 7006, "Zoom 미팅 생성에 실패했습니다."),
+    ZOOM_NOT_CONNECTED(HttpStatus.BAD_REQUEST, 7007, "전문가 Zoom 계정이 연동되어 있지 않습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/InMemoryZoomOAuthStateStore.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/InMemoryZoomOAuthStateStore.java
@@ -1,0 +1,40 @@
+package com.ceos.menual.domain.expert.service.zoom;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Profile({"local", "test"})
+public class InMemoryZoomOAuthStateStore implements ZoomOAuthStateStore {
+
+    private static final class Entry {
+        private final Long userId;
+        private final long expiresAtMillis;
+
+        private Entry(Long userId, long expiresAtMillis) {
+            this.userId = userId;
+            this.expiresAtMillis = expiresAtMillis;
+        }
+    }
+
+    private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(String state, Long userId, Duration ttl) {
+        long expiresAt = System.currentTimeMillis() + ttl.toMillis();
+        store.put(state, new Entry(userId, expiresAt));
+    }
+
+    @Override
+    public Optional<Long> consume(String state) {
+        Entry entry = store.remove(state);
+        if (entry == null) return Optional.empty();
+        if (System.currentTimeMillis() > entry.expiresAtMillis) return Optional.empty();
+        return Optional.of(entry.userId);
+    }
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/RedisZoomOAuthStateStore.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/RedisZoomOAuthStateStore.java
@@ -25,9 +25,8 @@ public class RedisZoomOAuthStateStore implements ZoomOAuthStateStore {
     @Override
     public Optional<Long> consume(String state) {
         String key = PREFIX + state;
-        String val = redis.opsForValue().get(key);
+        String val = redis.opsForValue().getAndDelete(key);
         if (val == null) return Optional.empty();
-        redis.delete(key); // 1회성
         try {
             return Optional.of(Long.parseLong(val));
         } catch (NumberFormatException e) {

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/RedisZoomOAuthStateStore.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/RedisZoomOAuthStateStore.java
@@ -1,0 +1,38 @@
+package com.ceos.menual.domain.expert.service.zoom;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@Profile("prod")
+@RequiredArgsConstructor
+public class RedisZoomOAuthStateStore implements ZoomOAuthStateStore {
+
+    private static final String PREFIX = "zoom:oAuthState:";
+
+    private final StringRedisTemplate redis;
+
+    @Override
+    public void save(String state, Long userId, Duration ttl) {
+        redis.opsForValue().set(PREFIX + state, String.valueOf(userId), ttl);
+    }
+
+    @Override
+    public Optional<Long> consume(String state) {
+        String key = PREFIX + state;
+        String val = redis.opsForValue().get(key);
+        if (val == null) return Optional.empty();
+        redis.delete(key); // 1회성
+        try {
+            return Optional.of(Long.parseLong(val));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomMeetingService.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomMeetingService.java
@@ -1,0 +1,152 @@
+package com.ceos.menual.domain.expert.service.zoom;
+
+import com.ceos.menual.domain.consultation.repository.ConsultationRepository;
+import com.ceos.menual.domain.expert.api.ZoomOauthClient;
+import com.ceos.menual.domain.expert.dto.response.ZoomCreateMeetingResponseDTO;
+import com.ceos.menual.domain.expert.dto.response.ZoomTokenResponseDTO;
+import com.ceos.menual.domain.expert.exception.ZoomErrorCode;
+import com.ceos.menual.global.exception.GlobalException;
+import com.ceos.menual.entity.Consultation;
+import com.ceos.menual.entity.ExpertProfile;
+import com.ceos.menual.entity.enums.ConsultationType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ZoomMeetingService {
+
+    private final ZoomProperties zoomProperties;
+    private final ZoomOauthClient zoomOauthClient;
+    private final WebClient zoomApiWebClient;
+    private final ConsultationRepository consultationRepository;
+
+    @Transactional
+    public void createMeetingAndSave(Long consultationId) {
+        Consultation consultation = consultationRepository.findByIdWithAllRelations(consultationId)
+            .orElseThrow(() -> new GlobalException(com.ceos.menual.domain.consultation.exception.ConsultationErrorCode.CONSULTATION_NOT_FOUND));
+
+        log.info("Zoom meeting create requested - consultationId={}, type={}, alreadyCreated={}",
+            consultationId, consultation.getType(), consultation.getIsZoomMeetingCreated());
+
+        if (consultation.getType() != ConsultationType.VIDEO) return;
+        if (Boolean.TRUE.equals(consultation.getIsZoomMeetingCreated())) return;
+
+        ExpertProfile expertProfile = consultation.getExpertProfile();
+        if (expertProfile == null || !Boolean.TRUE.equals(expertProfile.getIsZoomConnected())
+            || expertProfile.getZoomUserId() == null
+            || expertProfile.getZoomAccessToken() == null
+            || expertProfile.getZoomRefreshToken() == null) {
+            throw new GlobalException(ZoomErrorCode.ZOOM_NOT_CONNECTED);
+        }
+
+        String accessToken = getValidAccessToken(expertProfile);
+
+        ZoomCreateMeetingResponseDTO meeting = callCreateMeeting(
+            expertProfile.getZoomUserId(),
+            accessToken,
+            consultation
+        );
+
+        consultation.attachZoomMeeting(meeting.getId(), meeting.getJoinUrl());
+        consultationRepository.saveAndFlush(consultation);
+
+        // 저장 확인(디버깅): DB 재조회로 값이 실제로 들어갔는지 로그로 확정
+        consultationRepository.findById(consultationId).ifPresent(saved -> {
+            log.info("Zoom meeting saved - consultationId={}, zoomMeetingId={}, zoomJoinUrlPresent={}",
+                consultationId,
+                saved.getZoomMeetingId(),
+                saved.getZoomJoinUrl() != null && !saved.getZoomJoinUrl().isBlank()
+            );
+        });
+    }
+
+    /**
+     * AFTER_COMMIT 리스너에서 호출되는 외부 API + DB 갱신 로직은 "커밋 이후"라 기존 트랜잭션이 종료된 상태
+     * -> 별도의 새 트랜잭션에서 저장/flush가 가능하도록 분리
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createMeetingAndSaveInNewTx(Long consultationId) {
+        createMeetingAndSave(consultationId);
+    }
+
+    private String getValidAccessToken(ExpertProfile expertProfile) {
+        LocalDateTime expiresAt = expertProfile.getZoomTokenExpiresAt();
+        boolean expired = expiresAt != null && expiresAt.isBefore(LocalDateTime.now().minusSeconds(30));
+        if (!expired) return expertProfile.getZoomAccessToken();
+
+        ZoomTokenResponseDTO refreshed = zoomOauthClient.refreshAccessToken(
+            zoomProperties.getClientId(),
+            zoomProperties.getClientSecret(),
+            expertProfile.getZoomRefreshToken()
+        );
+
+        LocalDateTime newExpiresAt = LocalDateTime.now().plusSeconds(
+            refreshed.getExpiresIn() != null ? refreshed.getExpiresIn() : 3600
+        );
+        expertProfile.updateZoomAccessToken(refreshed.getAccessToken(), newExpiresAt);
+
+        // Zoom은 refresh 응답에 refresh_token을 같이 줄 수도/안 줄 수도 있음
+        if (refreshed.getRefreshToken() != null && !refreshed.getRefreshToken().isBlank()) {
+            expertProfile.connectZoom(expertProfile.getZoomUserId(), refreshed.getAccessToken(), refreshed.getRefreshToken(), newExpiresAt);
+        }
+
+        return refreshed.getAccessToken();
+    }
+
+    private ZoomCreateMeetingResponseDTO callCreateMeeting(String zoomUserId, String accessToken, Consultation consultation) {
+        try {
+            LocalDateTime start = consultation.getScheduleTime();
+            if (start == null) start = LocalDateTime.now().plusMinutes(10);
+
+            int duration = consultation.getDurationMinutes() != null ? consultation.getDurationMinutes() : 60;
+
+            String topic = "[Menual] 화상 상담";
+            String startTime = start.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+            Map<String, Object> body = Map.of(
+                "topic", topic,
+                "type", 2,
+                "start_time", startTime,
+                "duration", duration,
+                "timezone", "Asia/Seoul",
+                "settings", Map.of(
+                    "join_before_host", false,
+                    "waiting_room", true
+                )
+            );
+
+            ZoomCreateMeetingResponseDTO res = zoomApiWebClient.post()
+                .uri("/v2/users/{userId}/meetings", zoomUserId)
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(ZoomCreateMeetingResponseDTO.class)
+                .block();
+
+            if (res == null || res.getId() == null || res.getJoinUrl() == null) {
+                throw new GlobalException(ZoomErrorCode.ZOOM_MEETING_CREATE_FAILED);
+            }
+            return res;
+        } catch (WebClientResponseException e) {
+            // Zoom이 4xx/5xx를 내려주는 케이스(권한 부족/토큰 만료/스코프 부족 등)
+            log.error("Zoom create meeting failed - status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new GlobalException(ZoomErrorCode.ZOOM_MEETING_CREATE_FAILED);
+        } catch (WebClientRequestException e) {
+            throw new GlobalException(ZoomErrorCode.ZOOM_MEETING_CREATE_FAILED);
+        }
+    }
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomMeetingService.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomMeetingService.java
@@ -84,7 +84,7 @@ public class ZoomMeetingService {
 
     private String getValidAccessToken(ExpertProfile expertProfile) {
         LocalDateTime expiresAt = expertProfile.getZoomTokenExpiresAt();
-        boolean expired = expiresAt != null && expiresAt.isBefore(LocalDateTime.now().minusSeconds(30));
+        boolean expired = expiresAt == null || expiresAt.isBefore(LocalDateTime.now().minusSeconds(30));
         if (!expired) return expertProfile.getZoomAccessToken();
 
         ZoomTokenResponseDTO refreshed = zoomOauthClient.refreshAccessToken(

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomOAuthCallbackResult.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomOAuthCallbackResult.java
@@ -1,0 +1,19 @@
+package com.ceos.menual.domain.expert.service.zoom;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ZoomOAuthCallbackResult {
+    private Long expertUserId;
+    private String zoomUserId;
+    private String zoomEmail;
+
+    private String accessToken;
+    private String refreshToken;
+    private LocalDateTime tokenExpiresAt;
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomOAuthService.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomOAuthService.java
@@ -1,0 +1,133 @@
+package com.ceos.menual.domain.expert.service.zoom;
+
+import com.ceos.menual.domain.expert.api.ZoomOauthClient;
+import com.ceos.menual.domain.expert.dto.response.ZoomTokenResponseDTO;
+import com.ceos.menual.domain.expert.dto.response.ZoomUserInfoResponseDTO;
+import com.ceos.menual.domain.expert.exception.ZoomErrorCode;
+import com.ceos.menual.domain.reservation.exception.ReservationErrorCode;
+import com.ceos.menual.domain.user.exception.UserErrorCode;
+import com.ceos.menual.domain.user.repository.UserRepository;
+import com.ceos.menual.global.exception.GlobalException;
+import com.ceos.menual.entity.User;
+import com.ceos.menual.entity.enums.UserType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ZoomOAuthService {
+
+    private static final Duration STATE_TTL = Duration.ofMinutes(10);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final ZoomProperties zoomProperties;
+    private final ZoomOAuthStateStore stateStore;
+    private final ZoomOauthClient zoomOauthClient;
+    private final UserRepository userRepository;
+
+    public URI buildAuthorizeRedirectUrl(Long expertUserId) {
+        validateConfig();
+
+        String state = generateState();
+        stateStore.save(state, expertUserId, STATE_TTL);
+
+        // scope는 공백으로 구분되는 경우가 많아(URL에선 %20로 인코딩 필요)
+        // build(true)는 "이미 인코딩된 값"으로 간주하여 공백을 허용하지 않으므로 encode()를 사용
+        UriComponentsBuilder builder = UriComponentsBuilder
+            .fromHttpUrl("https://zoom.us/oauth/authorize")
+            .queryParam("response_type", "code")
+            .queryParam("client_id", zoomProperties.getClientId())
+            .queryParam("redirect_uri", zoomProperties.getRedirectUri())
+            .queryParam("state", state);
+
+        if (!isBlank(zoomProperties.getScope())) {
+            builder.queryParam("scope", zoomProperties.getScope());
+        }
+
+        return builder.build().encode().toUri();
+    }
+
+    /**
+     * code/state로 토큰 교환 후 /users/me 호출까지 수행
+     * ExpertProfile에 Zoom 연동 정보를 저장
+     */
+    @Transactional
+    public ZoomOAuthCallbackResult handleCallback(String code, String state) {
+        validateConfig();
+
+        Long expertUserId = stateStore.consume(state)
+            .orElseThrow(() -> new GlobalException(ZoomErrorCode.ZOOM_OAUTH_STATE_INVALID));
+
+        log.info("Zoom OAuth callback received - expertUserId={}", expertUserId);
+
+        ZoomTokenResponseDTO token = zoomOauthClient.exchangeCodeForToken(
+            zoomProperties.getClientId(),
+            zoomProperties.getClientSecret(),
+            zoomProperties.getRedirectUri(),
+            code
+        );
+
+        ZoomUserInfoResponseDTO me = zoomOauthClient.getUserInfo(token.getAccessToken());
+
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(
+            token.getExpiresIn() != null ? token.getExpiresIn() : 3600
+        );
+
+        // ExpertProfile에 Zoom 연동 정보 저장
+        User expertUser = userRepository.findById(expertUserId)
+            .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        if (expertUser.getUserType() != UserType.EXPERT || expertUser.getExpertProfile() == null) {
+            throw new GlobalException(ReservationErrorCode.EXPERT_PROFILE_NOT_FOUND);
+        }
+
+        expertUser.getExpertProfile().connectZoom(
+            me.getId(),
+            token.getAccessToken(),
+            token.getRefreshToken(),
+            expiresAt
+        );
+
+        // dirty checking 보장 + 디버깅 편의용
+        userRepository.saveAndFlush(expertUser);
+        log.info("Zoom connected and saved - expertUserId={}, zoomUserId={}, expiresAt={}",
+            expertUserId, me.getId(), expiresAt);
+
+        return ZoomOAuthCallbackResult.builder()
+            .expertUserId(expertUserId)
+            .zoomUserId(me.getId())
+            .zoomEmail(me.getEmail())
+            .tokenExpiresAt(expiresAt)
+            .build();
+    }
+
+    private void validateConfig() {
+        if (isBlank(zoomProperties.getClientId())
+            || isBlank(zoomProperties.getClientSecret())
+            || isBlank(zoomProperties.getRedirectUri())) {
+            throw new GlobalException(ZoomErrorCode.ZOOM_OAUTH_NOT_CONFIGURED);
+        }
+    }
+
+    private String generateState() {
+        byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomOAuthStateStore.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomOAuthStateStore.java
@@ -1,0 +1,14 @@
+package com.ceos.menual.domain.expert.service.zoom;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface ZoomOAuthStateStore {
+    void save(String state, Long userId, Duration ttl);
+
+    /**
+     * 1회성 사용을 위해 조회와 동시에 삭제
+     */
+    Optional<Long> consume(String state);
+}
+

--- a/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomProperties.java
+++ b/src/main/java/com/ceos/menual/domain/expert/service/zoom/ZoomProperties.java
@@ -1,0 +1,29 @@
+package com.ceos.menual.domain.expert.service.zoom;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "zoom")
+public class ZoomProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String scope;
+    /**
+     * OAuth 콜백 처리 후 프론트로 리다이렉트할 URI
+     * 예: https://menual.site/experts/zoom/success
+     */
+    private String successRedirectUri;
+
+    /**
+     * OAuth 콜백 처리 실패 시 프론트로 리다이렉트할 URI
+     * 예: https://menual.site/experts/zoom/failure
+     */
+    private String failureRedirectUri;
+}
+

--- a/src/main/java/com/ceos/menual/domain/reservation/dto/request/UpdateReservationConcernRequestDTO.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/dto/request/UpdateReservationConcernRequestDTO.java
@@ -32,7 +32,7 @@ public class UpdateReservationConcernRequestDTO {
     @JsonProperty("hair")
     private HairConcernDTO hair;
 
-    @Schema(description = "S3 이미지 키 목록", example = "[\"tmp/consultation/user-123/purpose/1.jpg\"]", required = true)
+    @Schema(description = "S3 이미지 키 목록", example = "[\"tmp/consultation/reservation-123/{imageType}/{fileName}\"]", required = true)
     @NotEmpty(message = "최소 1개 이상의 이미지 키를 포함해야 합니다")
     private List<String> imageKeys;
 }

--- a/src/main/java/com/ceos/menual/domain/reservation/event/ReservationConfirmedEvent.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/event/ReservationConfirmedEvent.java
@@ -1,0 +1,8 @@
+package com.ceos.menual.domain.reservation.event;
+
+public record ReservationConfirmedEvent(
+    Long reservationId,
+    Long consultationId,
+    Long adminUserId
+) {}
+

--- a/src/main/java/com/ceos/menual/domain/reservation/event/ReservationConfirmedListeners.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/event/ReservationConfirmedListeners.java
@@ -1,0 +1,69 @@
+package com.ceos.menual.domain.reservation.event;
+
+import com.ceos.menual.domain.expert.service.zoom.ZoomMeetingService;
+import com.ceos.menual.domain.reservation.repository.ReservationRepository;
+import com.ceos.menual.domain.reservation.service.ReservationService;
+import com.ceos.menual.entity.Reservation;
+import com.ceos.menual.global.exception.GlobalException;
+import com.ceos.menual.domain.reservation.exception.ReservationErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationConfirmedListeners {
+
+    private final ReservationRepository reservationRepository;
+    private final ReservationService reservationService;
+    private final ZoomMeetingService zoomMeetingService;
+
+    /**
+     * 채팅방 생성/고민지 전송
+     * - 결제확인 트랜잭션 안에서 동기 실행
+     */
+    @EventListener
+    public void onReservationConfirmedEssential(ReservationConfirmedEvent event) {
+        log.info("ReservationConfirmedEvent received (essential) - reservationId={}, consultationId={}, adminUserId={}",
+            event.reservationId(), event.consultationId(), event.adminUserId());
+
+        Reservation reservation = reservationRepository.findById(event.reservationId())
+            .orElseThrow(() -> new GlobalException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        if (reservation.getConsultation() == null) {
+            throw new GlobalException(ReservationErrorCode.RESERVATION_NOT_FOUND);
+        }
+
+        reservationService.createChatroomsAndSendConcern(
+            reservation.getConsultation(),
+            reservation,
+            event.adminUserId()
+        );
+    }
+
+    /**
+     * 부가 후처리: Zoom 미팅 생성 및 링크 전송
+     * - 트랜잭션 커밋 이후 실행(외부 API 호출이 DB 트랜잭션을 길게 잡지 않도록)
+     * - 추후 @Async 추가하면 응답시간 최적화 가능
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onReservationConfirmedCreateZoom(ReservationConfirmedEvent event) {
+        log.info("ReservationConfirmedEvent received (after_commit) - reservationId={}, consultationId={}, adminUserId={}",
+            event.reservationId(), event.consultationId(), event.adminUserId());
+
+        // AFTER_COMMIT 리스너는 트랜잭션이 없는 상태일 수 있어 LAZY 접근을 피합니다.
+        try {
+            // Zoom 미팅은 결제 확정 직후 생성 후 DB에 저장합니다.
+            zoomMeetingService.createMeetingAndSaveInNewTx(event.consultationId());
+            log.info("Zoom meeting job completed - consultationId={}", event.consultationId());
+        } catch (Exception e) {
+            // 결제확정 자체는 완료된 상태이므로, 여기서는 로깅만 하고 종료합니다.
+            log.error("Zoom meeting job failed - consultationId={}", event.consultationId(), e);
+        }
+    }
+}
+

--- a/src/main/java/com/ceos/menual/domain/reservation/event/ReservationConfirmedListeners.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/event/ReservationConfirmedListeners.java
@@ -8,7 +8,6 @@ import com.ceos.menual.global.exception.GlobalException;
 import com.ceos.menual.domain.reservation.exception.ReservationErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.event.TransactionPhase;
@@ -24,25 +23,31 @@ public class ReservationConfirmedListeners {
 
     /**
      * 채팅방 생성/고민지 전송
-     * - 결제확인 트랜잭션 안에서 동기 실행
+     * - 트랜잭션 커밋 이후 실행(채팅방 생성 실패가 결제확정 롤백을 유발하지 않도록)
      */
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onReservationConfirmedEssential(ReservationConfirmedEvent event) {
         log.info("ReservationConfirmedEvent received (essential) - reservationId={}, consultationId={}, adminUserId={}",
             event.reservationId(), event.consultationId(), event.adminUserId());
 
-        Reservation reservation = reservationRepository.findById(event.reservationId())
-            .orElseThrow(() -> new GlobalException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        try {
+            Reservation reservation = reservationRepository.findById(event.reservationId())
+                .orElseThrow(() -> new GlobalException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
-        if (reservation.getConsultation() == null) {
-            throw new GlobalException(ReservationErrorCode.RESERVATION_NOT_FOUND);
+            if (reservation.getConsultation() == null) {
+                throw new GlobalException(ReservationErrorCode.CONSULTATION_NOT_LINKED);
+            }
+
+            reservationService.createChatroomsAndSendConcern(
+                reservation.getConsultation(),
+                reservation,
+                event.adminUserId()
+            );
+        } catch (Exception e) {
+            // 결제확정 자체는 완료된 상태이므로, 여기서는 로깅만 하고 종료합니다.
+            log.error("ReservationConfirmed essential job failed - reservationId={}, consultationId={}",
+                event.reservationId(), event.consultationId(), e);
         }
-
-        reservationService.createChatroomsAndSendConcern(
-            reservation.getConsultation(),
-            reservation,
-            event.adminUserId()
-        );
     }
 
     /**

--- a/src/main/java/com/ceos/menual/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/exception/ReservationErrorCode.java
@@ -26,7 +26,8 @@ public enum ReservationErrorCode implements ResultCode {
     MISSING_FASHION_CONCERN_DATA(HttpStatus.BAD_REQUEST, 4015, "패션 상담 고민지 데이터가 필요합니다."),
     MISSING_HAIR_CONCERN_DATA(HttpStatus.BAD_REQUEST, 4016, "헤어 상담 고민지 데이터가 필요합니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, 4017, "예약 카테고리와 요청 카테고리가 일치하지 않습니다."),
-    INVALID_CONSULTATION_TYPE(HttpStatus.BAD_REQUEST, 4018, "유효하지 않은 상담 유형입니다.");
+    INVALID_CONSULTATION_TYPE(HttpStatus.BAD_REQUEST, 4018, "유효하지 않은 상담 유형입니다."),
+    CONSULTATION_NOT_LINKED(HttpStatus.NOT_FOUND, 4019, "예약과 연결된 상담이 존재하지 않습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/ceos/menual/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/exception/ReservationErrorCode.java
@@ -22,7 +22,7 @@ public enum ReservationErrorCode implements ResultCode {
     UNAUTHORIZED_RESERVATION_ACCESS(HttpStatus.FORBIDDEN, 4011, "해당 예약에 대한 접근 권한이 없습니다."),
     CONCERN_JSON_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 4012, "고민지 JSON 변환 중 오류가 발생했습니다."),
     INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, 4013, "유효하지 않은 예약 상태입니다."),
-    INVALID_IMAGE_KEY_FORMAT(HttpStatus.BAD_REQUEST, 4014, "잘못된 이미지 키 형식입니다. 형식: tmp/consultation/user-{userId}/{imageType}/{fileName}"),
+    INVALID_IMAGE_KEY_FORMAT(HttpStatus.BAD_REQUEST, 4014, "잘못된 이미지 키 형식입니다. 형식: tmp/consultation/reservation-{reservationId}/{imageType}/{fileName}"),
     MISSING_FASHION_CONCERN_DATA(HttpStatus.BAD_REQUEST, 4015, "패션 상담 고민지 데이터가 필요합니다."),
     MISSING_HAIR_CONCERN_DATA(HttpStatus.BAD_REQUEST, 4016, "헤어 상담 고민지 데이터가 필요합니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, 4017, "예약 카테고리와 요청 카테고리가 일치하지 않습니다."),

--- a/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
@@ -641,7 +641,7 @@ public class ReservationService {
 
     /**
      * S3 임시 저장된 이미지를 최종 위치로 이동
-     * tmp/consultation/user-{userId}/{imageType}/{fileName}
+     * tmp/consultation/reservation-{reservationId}/{imageType}/{fileName}
      *     → final/consultation/{consultationId}/{imageType}/{fileName}
      */
     private void moveImagesToFinalLocation(Reservation reservation, Consultation consultation) {

--- a/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
@@ -27,6 +27,7 @@ import com.ceos.menual.domain.reservation.repository.AvailableScheduleRepository
 import com.ceos.menual.domain.reservation.repository.ReservationRepository;
 import com.ceos.menual.domain.user.exception.UserErrorCode;
 import com.ceos.menual.domain.user.repository.UserRepository;
+import com.ceos.menual.domain.reservation.event.ReservationConfirmedEvent;
 import com.ceos.menual.entity.*;
 import com.ceos.menual.entity.enums.*;
 import com.ceos.menual.entity.enums.Category;
@@ -36,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -59,6 +61,7 @@ public class ReservationService {
     private final ConsultationScheduleRepository consultationScheduleRepository;
     private final ChatMessageService chatMessageService;
     private final ChatroomRepository chatroomRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private static final List<ReservationStatus> ACTIVE_RESERVATION_STATUSES =
             List.of(ReservationStatus.UNPAID, ReservationStatus.PAID);
@@ -121,9 +124,13 @@ public class ReservationService {
 
         // S3 임시 이미지를 최종 위치로 이동
         moveImagesToFinalLocation(reservation, savedConsultation);
-        
-        // 채팅방 자동 생성 및 고민지 전송
-        createChatroomsAndSendConcern(savedConsultation, reservation, adminUserId);
+
+        // 결제 확정 이벤트 발행
+        eventPublisher.publishEvent(new ReservationConfirmedEvent(
+            reservationId,
+            savedConsultation.getId(),
+            adminUserId
+        ));
 
         log.info("관리자 결제 확인 및 상담 생성 완료 - reservationId: {}, consultationId: {}",
                 reservationId, savedConsultation.getId());

--- a/src/main/java/com/ceos/menual/entity/Consultation.java
+++ b/src/main/java/com/ceos/menual/entity/Consultation.java
@@ -20,10 +20,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Table(name = "consultations")
@@ -56,6 +57,14 @@ public class Consultation extends BaseEntity {
 	private Integer durationMinutes;
 	private String videoLink;
 
+	// Zoom 미팅 관련 (자동 생성)
+	private Long zoomMeetingId;
+
+	@Column(columnDefinition = "TEXT")
+	private String zoomJoinUrl;
+
+	private Boolean isZoomMeetingCreated;
+
 	//솔루션 관련
 	@Column(columnDefinition = "TEXT")
 	private String solution;
@@ -81,4 +90,10 @@ public class Consultation extends BaseEntity {
     public void markReviewAsWritten() {
         this.reviewWritten = true;
     }
+
+	public void attachZoomMeeting(Long meetingId, String joinUrl) {
+		this.zoomMeetingId = meetingId;
+		this.zoomJoinUrl = joinUrl;
+		this.isZoomMeetingCreated = true;
+	}
 }

--- a/src/main/java/com/ceos/menual/entity/ExpertProfile.java
+++ b/src/main/java/com/ceos/menual/entity/ExpertProfile.java
@@ -1,6 +1,7 @@
 package com.ceos.menual.entity;
 
 import com.ceos.menual.entity.enums.Category;
+import com.ceos.menual.global.converter.ZoomTokenEncryptor;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -64,9 +65,11 @@ public class ExpertProfile extends BaseEntity {
 	private String zoomUserId;
 
 	@Column(columnDefinition = "TEXT")
+	@Convert(converter = ZoomTokenEncryptor.class)
 	private String zoomAccessToken;
 
 	@Column(columnDefinition = "TEXT")
+	@Convert(converter = ZoomTokenEncryptor.class)
 	private String zoomRefreshToken;
 
 	private LocalDateTime zoomTokenExpiresAt;

--- a/src/main/java/com/ceos/menual/entity/ExpertProfile.java
+++ b/src/main/java/com/ceos/menual/entity/ExpertProfile.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -58,6 +59,18 @@ public class ExpertProfile extends BaseEntity {
 	//경력정보
 	private String careerInfo;
 
+	// ===== Zoom 연동 =====
+	private Boolean isZoomConnected;
+	private String zoomUserId;
+
+	@Column(columnDefinition = "TEXT")
+	private String zoomAccessToken;
+
+	@Column(columnDefinition = "TEXT")
+	private String zoomRefreshToken;
+
+	private LocalDateTime zoomTokenExpiresAt;
+
 
 	// 비즈니스 메서드
 	public void addConsultationSchedule(ConsultationSchedule schedule) {
@@ -68,6 +81,20 @@ public class ExpertProfile extends BaseEntity {
 	public void removeConsultationSchedule(ConsultationSchedule schedule) {
 		this.consultationSchedules.remove(schedule);
 		schedule.setExpertProfile(null);
+	}
+
+	public void connectZoom(String zoomUserId, String accessToken, String refreshToken, LocalDateTime tokenExpiresAt) {
+		this.zoomUserId = zoomUserId;
+		this.zoomAccessToken = accessToken;
+		this.zoomRefreshToken = refreshToken;
+		this.zoomTokenExpiresAt = tokenExpiresAt;
+		this.isZoomConnected = true;
+	}
+
+	public void updateZoomAccessToken(String accessToken, LocalDateTime tokenExpiresAt) {
+		this.zoomAccessToken = accessToken;
+		this.zoomTokenExpiresAt = tokenExpiresAt;
+		if (this.isZoomConnected == null) this.isZoomConnected = true;
 	}
 
 }

--- a/src/main/java/com/ceos/menual/global/config/SecurityConfig.java
+++ b/src/main/java/com/ceos/menual/global/config/SecurityConfig.java
@@ -47,11 +47,13 @@ public class SecurityConfig {
                                 "/api/auth/login",
                                 "/api/auth/social-login",
 
+                                // Zoom OAuth 콜백 (Zoom 서버에서 redirect될 수 있어 permitAll)
+                                "/api/experts/zoom/callback",
+
                                 // 사용자 관련
                                 "/api/user/signup",
                                 "/api/user/social-signup",
 
-                                // TODO: http GET 메소드만 허용
                                 // 전문가 관련
                                 "/api/expert",
                                 "/api/expert/**",

--- a/src/main/java/com/ceos/menual/global/config/WebClientConfig.java
+++ b/src/main/java/com/ceos/menual/global/config/WebClientConfig.java
@@ -24,4 +24,19 @@ public class WebClientConfig {
 			.defaultHeader("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 			.build();
 	}
+
+	@Bean
+	public WebClient zoomAuthWebClient() {
+		return WebClient.builder()
+			.baseUrl("https://zoom.us")
+			.defaultHeader("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+			.build();
+	}
+
+	@Bean
+	public WebClient zoomApiWebClient() {
+		return WebClient.builder()
+			.baseUrl("https://api.zoom.us")
+			.build();
+	}
 }

--- a/src/main/java/com/ceos/menual/global/converter/ZoomTokenEncryptor.java
+++ b/src/main/java/com/ceos/menual/global/converter/ZoomTokenEncryptor.java
@@ -1,0 +1,152 @@
+package com.ceos.menual.global.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Zoom OAuth 토큰(access/refresh)을 DB에 저장할 때 암호화/복호화하기 위한 JPA AttributeConverter.
+ *
+ * <p>키는 코드에 하드코딩하지 않고, 런타임 환경변수/시크릿에서 주입해야 합니다.</p>
+ *
+ * <ul>
+ *   <li>환경변수: {@code ZOOM_TOKEN_ENCRYPTION_KEY} (Base64 인코딩된 AES 키, 16/24/32 bytes)</li>
+ * </ul>
+ *
+ * <p>저장 포맷: {@code v1:<base64url(iv)>:<base64url(ciphertextWithTag)>}</p>
+ */
+@Converter
+public class ZoomTokenEncryptor implements AttributeConverter<String, String> {
+
+    private static final String ENV_KEY = "ZOOM_TOKEN_ENCRYPTION_KEY";
+    private static final String PREFIX = "v1:";
+    private static final int IV_LEN_BYTES = 12; // 권장: 96-bit
+    private static final int TAG_LEN_BITS = 128;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private static final Base64.Encoder B64URL_ENC = Base64.getUrlEncoder().withoutPadding();
+    private static final Base64.Decoder B64URL_DEC = Base64.getUrlDecoder();
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        if (attribute.isBlank()) return attribute;
+        if (attribute.startsWith(PREFIX)) return attribute; // 방어적(이중 암호화 방지)
+
+        SecretKey key = loadKeyOrThrow();
+        byte[] iv = new byte[IV_LEN_BYTES];
+        SECURE_RANDOM.nextBytes(iv);
+
+        try {
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_LEN_BITS, iv));
+            cipher.updateAAD(PREFIX.getBytes(StandardCharsets.UTF_8));
+            byte[] ciphertext = cipher.doFinal(attribute.getBytes(StandardCharsets.UTF_8));
+
+            return PREFIX + B64URL_ENC.encodeToString(iv) + ":" + B64URL_ENC.encodeToString(ciphertext);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Failed to encrypt Zoom token", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        if (dbData.isBlank()) return dbData;
+
+        // 레거시(평문) 데이터는 그대로 반환 → 이후 저장 시 암호화로 자연스럽게 마이그레이션
+        if (!dbData.startsWith(PREFIX)) return dbData;
+
+        SecretKey key = loadKeyOrThrow();
+
+        String payload = dbData.substring(PREFIX.length());
+        int sep = payload.indexOf(':');
+        if (sep <= 0 || sep == payload.length() - 1) {
+            throw new IllegalStateException("Invalid encrypted token format");
+        }
+
+        byte[] iv = B64URL_DEC.decode(payload.substring(0, sep));
+        byte[] ciphertext = B64URL_DEC.decode(payload.substring(sep + 1));
+
+        try {
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_LEN_BITS, iv));
+            cipher.updateAAD(PREFIX.getBytes(StandardCharsets.UTF_8));
+            byte[] plaintext = cipher.doFinal(ciphertext);
+            return new String(plaintext, StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Failed to decrypt Zoom token", e);
+        }
+    }
+
+    private static SecretKey loadKeyOrThrow() {
+        // Spring 주입을 못 받으므로, (1) 환경변수 → (2) .env 파일 순서로 찾습니다.
+        String b64 = System.getenv(ENV_KEY);
+        if (b64 == null || b64.isBlank()) {
+            b64 = readFromDotEnv(ENV_KEY);
+        }
+        if (b64 == null || b64.isBlank()) {
+            throw new IllegalStateException("Missing encryption key: " + ENV_KEY + " (env var or .env)");
+        }
+
+        byte[] raw;
+        try {
+            raw = Base64.getDecoder().decode(b64.trim());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid Base64 in env var: " + ENV_KEY, e);
+        }
+
+        if (!(raw.length == 16 || raw.length == 24 || raw.length == 32)) {
+            throw new IllegalStateException(
+                "Invalid AES key length for " + ENV_KEY + ": " + raw.length + " bytes (expected 16/24/32)"
+            );
+        }
+
+        return new SecretKeySpec(raw, "AES");
+    }
+
+    private static String readFromDotEnv(String key) {
+        // 프로젝트 루트(working directory)의 ".env" 파일을 단순 key=value 형태로 읽습니다.
+        // 주의: 키/값을 로그로 남기지 않습니다.
+        Path path = Path.of(".env");
+        if (!Files.exists(path)) return null;
+
+        try {
+            List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
+            for (String line : lines) {
+                if (line == null) continue;
+                String trimmed = line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) continue;
+
+                int eq = trimmed.indexOf('=');
+                if (eq <= 0) continue;
+
+                String k = trimmed.substring(0, eq).trim();
+                if (!key.equals(k)) continue;
+
+                String v = trimmed.substring(eq + 1).trim();
+                // 따옴표가 있으면 제거 (dotenv 호환)
+                if ((v.startsWith("\"") && v.endsWith("\"")) || (v.startsWith("'") && v.endsWith("'"))) {
+                    v = v.substring(1, v.length() - 1);
+                }
+                return v;
+            }
+            return null;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to read .env for key: " + key, e);
+        }
+    }
+}
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,3 +13,5 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+zoom:
+  redirect-uri: https://api.menual.site/api/experts/zoom/callback

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,13 @@ logging:
   level:
     org.springframework.security: WARN
     com.ceos.menual: INFO
+
+zoom:
+  client-id: ${ZOOM_CLIENT_ID:}
+  client-secret: ${ZOOM_CLIENT_SECRET:}
+  redirect-uri: ${ZOOM_REDIRECT_URI:}
+  scope: ${ZOOM_SCOPE:meeting:write user:read}
+
+  # 콜백 처리 후 프론트로 리다이렉트
+  success-redirect-uri: ${ZOOM_OAUTH_SUCCESS_REDIRECT_URI:}
+  failure-redirect-uri: ${ZOOM_OAUTH_FAILURE_REDIRECT_URI:}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호 (깃허브 이슈 번호를 작성해주세요)
close #105 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1) OAuth 연동 시작(전문가가 “Zoom 연결” 버튼 클릭)
2) Zoom 콜백 처리(code/state 수신 → 토큰 교환 → 사용자 정보 조회 → DB 저장)
3) (상담이 VIDEO일 때) Zoom 미팅 생성 + 상담에 저장

## 📷스크린샷 (선택)

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 전문가가 Zoom 계정을 OAuth로 연결하고 연결 상태를 확인/저장 가능
  * 영상 상담 시 Zoom 미팅을 자동 생성하고 회의 ID·입장 URL을 상담에 저장
  * 예약 확정 시 채팅방 생성 및 Zoom 미팅 생성이 이벤트 기반으로 자동 처리
  * OAuth 상태 저장소(메모리/Redis), 토큰 암호화 및 토큰 갱신 흐름 지원
* **Chores**
  * Zoom 관련 설정(redirect 등) 및 콜백 공개 경로 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->