### PR TITLE
포인트 내역 조회 및 기존 채팅방 사용하도록 변경

### DIFF
--- a/src/main/java/com/ceos/menual/domain/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/ceos/menual/domain/chat/repository/ChatroomRepository.java
@@ -38,13 +38,16 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
     /**
      * 회원과 전문가 간의 특정 타입의 활성 채팅방 조회
+     * - 중복 데이터가 있어도 에러가 나지 않도록 List로 변경
+     * - ORDER BY c.createdAt DESC 추가 (가장 최근 방이 0번 인덱스에 오도록)
      */
     @Query("SELECT c FROM Chatroom c " +
             "WHERE c.member.id = :memberId " +
             "AND c.expert.id = :expertId " +
             "AND c.chatroomType = :chatroomType " +
-            "AND c.isActive = true")
-    Optional<Chatroom> findActiveChatroomByMemberAndExpertAndType(
+            "AND c.isActive = true " +
+            "ORDER BY c.createdAt DESC")
+    List<Chatroom> findActiveChatroomByMemberAndExpertAndType(
             @Param("memberId") Long memberId,
             @Param("expertId") Long expertId,
             @Param("chatroomType") ChatroomType chatroomType

--- a/src/main/java/com/ceos/menual/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ceos/menual/domain/chat/service/ChatroomService.java
@@ -64,19 +64,23 @@ public class ChatroomService {
         ChatroomType chatroomType = request.getChatroomType();
 
         // 같은 타입의 활성 채팅방이 있는지 확인
-        Optional<Chatroom> activeChatroom = chatroomRepository
+        List<Chatroom> activeChatrooms = chatroomRepository
                 .findActiveChatroomByMemberAndExpertAndType(
                         memberUser.getId(),
                         expertUser.getId(),
                         chatroomType
                 );
 
-        // TODO: 개발 단계에서는 검증 X
-//        if (activeChatroom.isPresent()) {
-//            log.warn("이미 진행 중인 {} 상담이 있습니다 - chatroomId: {}, memberId: {}, expertId: {}",
-//                    chatroomType, activeChatroom.get().getId(), memberUser.getId(), expertUser.getId());
-//            throw new GlobalException(ChatErrorCode.CONSULTATION_ALREADY_IN_PROGRESS);
-//        }
+        // 이미 활성 채팅방이 존재하는 경우 처리
+        if (!activeChatrooms.isEmpty()) {
+            // 가장 최근에 생성된 방 하나를 가져옴 (0번째 인덱스)
+            Chatroom existingChatroom = activeChatrooms.get(0);
+
+            log.warn("이미 진행 중인 {} 상담이 있습니다 - chatroomId: {}", chatroomType, existingChatroom.getId());
+
+            return makeChatroomResponse(existingChatroom, expertUser, memberUser, expertProfile);
+
+        }
 
         // 같은 타입의 비활성 채팅방이 있는지 확인
         List<Chatroom> inactiveChatrooms = chatroomRepository
@@ -224,6 +228,28 @@ public class ChatroomService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Chatroom 엔티티와 사용자 정보를 받아 Response DTO를 생성하는 헬퍼 메서드
+     */
+    private ChatroomResponseDTO makeChatroomResponse(
+            Chatroom chatroom,
+            User expertUser,
+            User memberUser,
+            ExpertProfile expertProfile
+    ) {
+        ChatroomResponseDTO.ExpertInfo expertInfo = ChatroomResponseDTO.ExpertInfo.builder()
+                .userId(expertUser.getId())
+                .nickname(expertUser.getNickname())
+                .category(expertProfile.getCategory().getDescription())
+                .build();
+
+        ChatroomResponseDTO.MemberInfo memberInfo = ChatroomResponseDTO.MemberInfo.builder()
+                .userId(memberUser.getId())
+                .nickname(memberUser.getNickname())
+                .build();
+
+        return ChatroomResponseDTO.of(chatroom, expertInfo, memberInfo);
+    }
 
     /**
      * Chatroom 엔티티를 DTO로 변환

--- a/src/main/java/com/ceos/menual/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ceos/menual/domain/chat/service/ChatroomService.java
@@ -76,7 +76,12 @@ public class ChatroomService {
             // 가장 최근에 생성된 방 하나를 가져옴 (0번째 인덱스)
             Chatroom existingChatroom = activeChatrooms.get(0);
 
-            log.warn("이미 진행 중인 {} 상담이 있습니다 - chatroomId: {}", chatroomType, existingChatroom.getId());
+            // consultationId 업데이트 및 저장
+            existingChatroom.updateConsultation(consultationId);
+            chatroomRepository.save(existingChatroom);
+
+            log.warn("이미 진행 중인 {} 상담이 있습니다 - chatroomId: {}, consultationId 업데이트: {}",
+                    chatroomType, existingChatroom.getId(), consultationId);
 
             return makeChatroomResponse(existingChatroom, expertUser, memberUser, expertProfile);
 

--- a/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
@@ -145,6 +145,17 @@ public class ReservationService {
         reservationRepository.save(reservation);
         log.info("예약 상태 업데이트 완료 - UNPAID → PAID, reservationId: {}", reservationId);
 
+        // 포인트 차감 처리
+        Integer pointsToDeduct = reservation.getPointsToUse();
+        if (pointsToDeduct != null && pointsToDeduct > 0) {
+            GeneralProfile generalProfile = reservation.getGeneralProfile();
+            generalProfile.deductPoints(pointsToDeduct);
+            log.info("포인트 차감 완료 - reservationId: {}, deductedPoints: {}, remainingPoints: {}",
+                    reservationId, pointsToDeduct, generalProfile.getTotalPoints());
+        } else {
+            log.info("차감할 포인트 없음 - reservationId: {}, pointsToUse: {}", reservationId, pointsToDeduct);
+        }
+
         // S3 임시 이미지를 최종 위치로 이동
         moveImagesToFinalLocation(reservation, savedConsultation);
 

--- a/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/ceos/menual/domain/reservation/service/ReservationService.java
@@ -62,6 +62,7 @@ public class ReservationService {
     private final ZoomMeetingService zoomMeetingService;
     private final com.ceos.menual.global.config.slack.SlackNotificationService slackNotificationService;
     private final ExpertRepository expertRepository;
+    private final com.ceos.menual.domain.user.repository.PointHistoryRepository pointHistoryRepository;
 
     private static final List<ReservationStatus> ACTIVE_RESERVATION_STATUSES =
             List.of(ReservationStatus.UNPAID, ReservationStatus.PAID);
@@ -149,7 +150,19 @@ public class ReservationService {
         Integer pointsToDeduct = reservation.getPointsToUse();
         if (pointsToDeduct != null && pointsToDeduct > 0) {
             GeneralProfile generalProfile = reservation.getGeneralProfile();
+            User user = generalProfile.getUser();
+
+            // 포인트 차감
             generalProfile.deductPoints(pointsToDeduct);
+
+            // 포인트 히스토리 기록 (음수로 저장)
+            PointHistory pointHistory = PointHistory.builder()
+                    .user(user)
+                    .point(-pointsToDeduct)  // 차감은 음수로 기록
+                    .description("포인트 사용 (예약 ID: " + reservationId + ")")
+                    .build();
+            pointHistoryRepository.save(pointHistory);
+
             log.info("포인트 차감 완료 - reservationId: {}, deductedPoints: {}, remainingPoints: {}",
                     reservationId, pointsToDeduct, generalProfile.getTotalPoints());
         } else {
@@ -1239,7 +1252,19 @@ public class ReservationService {
         Integer pointsToRestore = reservation.getPointsToUse();
         if (pointsToRestore != null && pointsToRestore > 0) {
             GeneralProfile generalProfile = reservation.getGeneralProfile();
+            User user = generalProfile.getUser();
+
+            // 포인트 복구
             generalProfile.addPoints(pointsToRestore);
+
+            // 포인트 히스토리 기록 (양수로 저장)
+            PointHistory pointHistory = PointHistory.builder()
+                    .user(user)
+                    .point(pointsToRestore)  // 환불은 양수로 기록
+                    .description("포인트 환불")
+                    .build();
+            pointHistoryRepository.save(pointHistory);
+
             log.info("포인트 원상복구 완료 - reservationId: {}, restoredPoints: {}, newTotalPoints: {}",
                     reservationId, pointsToRestore, generalProfile.getTotalPoints());
         } else {

--- a/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
+++ b/src/main/java/com/ceos/menual/domain/user/controller/UserController.java
@@ -88,4 +88,21 @@ public class UserController {
         ExpertConversionResponseDTO response = userService.convertToExpert(userId, requestDTO);
         return ResponseEntity.ok(CommonResponse.success(response));
     }
+
+    /**
+     * 포인트 적립 내역 조회
+     */
+    @Operation(
+            summary = "포인트 적립 내역 조회",
+            description = "사용자의 포인트 적립 및 사용 내역을 조회합니다. 현재 보유 포인트와 히스토리를 반환합니다."
+    )
+    @GetMapping("/points/history")
+    public ResponseEntity<CommonResponse<com.ceos.menual.domain.user.dto.response.PointHistoryListResponseDTO>> getPointHistory(
+            @Parameter(description = "사용자 ID", required = true)
+            @AuthenticationPrincipal Long userId
+    ) {
+        com.ceos.menual.domain.user.dto.response.PointHistoryListResponseDTO response =
+                userService.getPointHistory(userId);
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
 }

--- a/src/main/java/com/ceos/menual/domain/user/dto/response/PointHistoryListResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/user/dto/response/PointHistoryListResponseDTO.java
@@ -1,0 +1,18 @@
+package com.ceos.menual.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointHistoryListResponseDTO {
+
+    private Integer totalPoints;                    // 현재 보유 포인트
+    private List<PointHistoryResponseDTO> history;  // 포인트 내역 리스트
+}

--- a/src/main/java/com/ceos/menual/domain/user/dto/response/PointHistoryResponseDTO.java
+++ b/src/main/java/com/ceos/menual/domain/user/dto/response/PointHistoryResponseDTO.java
@@ -1,0 +1,28 @@
+package com.ceos.menual.domain.user.dto.response;
+
+import com.ceos.menual.entity.PointHistory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointHistoryResponseDTO {
+
+    private LocalDateTime date;         // 날짜
+    private Integer point_amount;             // 포인트 금액 (양수: 적립, 음수: 차감)
+    private String description;         // 설명
+
+    public static PointHistoryResponseDTO from(PointHistory pointHistory) {
+        return PointHistoryResponseDTO.builder()
+                .date(pointHistory.getCreatedAt())
+                .point_amount(pointHistory.getPoint())
+                .description(pointHistory.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/ceos/menual/domain/user/repository/PointHistoryRepository.java
+++ b/src/main/java/com/ceos/menual/domain/user/repository/PointHistoryRepository.java
@@ -3,5 +3,12 @@ package com.ceos.menual.domain.user.repository;
 import com.ceos.menual.entity.PointHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+
+    /**
+     * 사용자의 포인트 히스토리 조회 (최신순)
+     */
+    List<PointHistory> findByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/ceos/menual/domain/user/service/UserService.java
+++ b/src/main/java/com/ceos/menual/domain/user/service/UserService.java
@@ -44,6 +44,7 @@ public class UserService {
     private final ReviewRepository reviewRepository;
     private final GeneralProfileRepository generalProfileRepository;
     private final ExpertProfileRepository expertProfileRepository;
+    private final com.ceos.menual.domain.user.repository.PointHistoryRepository pointHistoryRepository;
 
     @Transactional
     public SignUpResponseDTO signUp(SignUpRequestDTO request) {
@@ -272,5 +273,46 @@ public class UserService {
             reviewCount = reviewRepository.countByConsultationGeneralProfileId(gp.getId());
         }
         return UserInfoResponseDTO.of(user, expertLikeCount, reviewCount);
+    }
+
+    /**
+     * 포인트 히스토리 조회
+     *
+     * 사용자의 포인트 적립 및 사용 내역을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 현재 보유 포인트와 포인트 히스토리 리스트
+     */
+    @Transactional(readOnly = true)
+    public com.ceos.menual.domain.user.dto.response.PointHistoryListResponseDTO getPointHistory(Long userId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        // GeneralProfile 조회
+        GeneralProfile generalProfile = user.getGeneralProfile();
+        if (generalProfile == null) {
+            throw new GlobalException(UserErrorCode.GENERAL_PROFILE_NOT_FOUND);
+        }
+
+        // 현재 보유 포인트
+        Integer totalPoints = generalProfile.getTotalPoints();
+        if (totalPoints == null) {
+            totalPoints = 0;
+        }
+
+        // 포인트 히스토리 조회 (최신순)
+        List<PointHistory> pointHistories = pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        // DTO 변환
+        List<com.ceos.menual.domain.user.dto.response.PointHistoryResponseDTO> historyDTOs =
+                pointHistories.stream()
+                        .map(com.ceos.menual.domain.user.dto.response.PointHistoryResponseDTO::from)
+                        .toList();
+
+        return com.ceos.menual.domain.user.dto.response.PointHistoryListResponseDTO.builder()
+                .totalPoints(totalPoints)
+                .history(historyDTOs)
+                .build();
     }
 }

--- a/src/main/java/com/ceos/menual/entity/GeneralProfile.java
+++ b/src/main/java/com/ceos/menual/entity/GeneralProfile.java
@@ -33,4 +33,11 @@ public class GeneralProfile extends BaseEntity {
 		this.totalPoints += points;
 	}
 
+	public void deductPoints(int points) {
+		if (this.totalPoints == null) {
+			this.totalPoints = 0;
+		}
+		this.totalPoints -= points;
+	}
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #132 (깃허브 이슈 번호를 작성해주세요)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷스크린샷 (선택)

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 포인트 내역 조회 API 및 응답 DTO 추가 (총포인트 및 히스토리 제공)
  * 예약 확정/취소 시 포인트 차감·복구 및 포인트 이력 기록 추가
* **Enhancements**
  * 채팅방 처리 로직 개선: 활성 채팅방이 여러 개일 경우 최신 활성 채팅방을 우선 사용하여 응답 반환
* **Bug Fixes**
  * 중복 활성 채팅방 발견 시 예외 대신 기존 채팅 재사용 처리로 변경

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->